### PR TITLE
ipq806x: sync upstream source code (#7270)

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -77,6 +77,17 @@
 	qcom,mpll = <5>;
 };
 
+&opp_table_l2 {
+	/delete-node/opp-1200000000;
+
+	opp-1400000000 {
+		opp-hz = /bits/ 64 <1400000000>;
+		opp-microvolt = <1150000>;
+		clock-latency-ns = <100000>;
+		opp-level = <2>;
+	};
+};
+
 &opp_table0 {
 	/* 
 	 * On ipq8065 1.2 ghz freq is not present

--- a/target/linux/ipq806x/patches-5.10/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
+++ b/target/linux/ipq806x/patches-5.10/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
@@ -75,7 +75,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  ##################################################################################
 --- /dev/null
 +++ b/drivers/cpufreq/qcom-cpufreq-krait.c
-@@ -0,0 +1,601 @@
+@@ -0,0 +1,603 @@
 +// SPDX-License-Identifier: GPL-2.0
 +
 +#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
@@ -115,9 +115,11 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +	int cpu, ret;
 +
 +	if (l2_pdev) {
++		int policy_cpu = policy->cpu;
++
 +		/* find the max freq across all core */
 +		for_each_present_cpu(cpu)
-+			if (cpu != index)
++			if (cpu != policy_cpu)
 +				target_freq = max(
 +					target_freq,
 +					(unsigned long)cpufreq_quick_get(cpu));
@@ -132,6 +134,18 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		level = dev_pm_opp_get_level(opp);
 +		dev_pm_opp_put(opp);
 +
++		/*
++		 * Hardware constraint:
++		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
++		 * Assume index 0 with the idle freq and level > 0 as 
++		 * any L2 freq > 384MHz.
++		 * Skip CPU freq change in this corner case.
++		 */
++		if (unlikely(index == 0 && level != 0)) {
++			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
++			return -EINVAL;
++		}
++
 +		opp = dev_pm_opp_find_level_exact(&l2_pdev->dev, level);
 +		if (IS_ERR(opp)) {
 +			dev_err(&l2_pdev->dev,
@@ -144,18 +158,6 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		ret = dev_pm_opp_set_rate(&l2_pdev->dev, target_freq);
 +		if (ret)
 +			return ret;
-+
-+		/*
-+		 * Hardware constraint:
-+		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
-+		 * Assume index 0 with the idle freq and level > 0 as 
-+		 * any L2 freq > 384MHz.
-+		 * Skip CPU freq change in this corner case.
-+		 */
-+		if (unlikely(index == 0 && level != 0)) {
-+			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
-+			return -EINVAL;
-+		}
 +	}
 +
 +	ret = dev_pm_opp_set_rate(priv->cpu_dev, freq * 1000);

--- a/target/linux/ipq806x/patches-5.10/098-3-add-fab-scaling-support-with-cpufreq.patch
+++ b/target/linux/ipq806x/patches-5.10/098-3-add-fab-scaling-support-with-cpufreq.patch
@@ -227,9 +227,9 @@
  
  #include "cpufreq-dt.h"
  
-@@ -54,6 +55,13 @@ static int set_target(struct cpufreq_pol
- 		level = dev_pm_opp_get_level(opp);
- 		dev_pm_opp_put(opp);
+@@ -68,6 +69,13 @@ static int set_target(struct cpufreq_pol
+ 			return -EINVAL;
+ 		}
  
 +		/*
 +		 * Scale fabrics with max freq across all cores

--- a/target/linux/ipq806x/patches-5.4/083-ipq8064-dtsi-additions.patch
+++ b/target/linux/ipq806x/patches-5.4/083-ipq8064-dtsi-additions.patch
@@ -26,7 +26,7 @@
  		};
  
  		cpu1: cpu@1 {
-@@ -38,11 +50,458 @@
+@@ -38,11 +50,476 @@
  			next-level-cache = <&L2>;
  			qcom,acc = <&acc1>;
  			qcom,saw = <&saw1>;
@@ -42,19 +42,9 @@
 +			cpu-idle-states = <&CPU_SPC>;
  		};
  
- 		L2: l2-cache {
- 			compatible = "cache";
- 			cache-level = <2>;
-+			qcom,saw = <&saw_l2>;
-+		};
-+
-+		qcom,l2 {
-+			qcom,l2-rates = <384000000 1000000000 1200000000>;
-+			qcom,l2-cpufreq = <384000000 600000000 1200000000>;
-+			qcom,l2-volt = <1100000 1100000 1150000>;
-+			qcom,l2-supply = <&smb208_s1a>;
-+		};
-+
+-		L2: l2-cache {
+-			compatible = "cache";
+-			cache-level = <2>;
 +		idle-states {
 +			CPU_SPC: spc {
 +				compatible = "qcom,idle-state-spc", "arm,idle-state";
@@ -66,6 +56,31 @@
 +		};
 +	};
 +
++	opp_table_l2: opp_table_l2 {
++		compatible = "operating-points-v2";
++
++		opp-384000000 {
++			opp-hz = /bits/ 64 <384000000>;
++			opp-microvolt = <1100000>;
++			clock-latency-ns = <100000>;
++			opp-level = <0>;
++		};
++
++		opp-1000000000 {
++			opp-hz = /bits/ 64 <1000000000>;
++			opp-microvolt = <1100000>;
++			clock-latency-ns = <100000>;
++			opp-level = <1>;
++		};
++
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <1150000>;
++			clock-latency-ns = <100000>;
++			opp-level = <2>;
++ 		};
++ 	};
++ 
 +	opp_table0: opp_table0 {
 +		compatible = "operating-points-v2-kryo-cpu";
 +		nvmem-cells = <&speedbin_efuse>;
@@ -78,6 +93,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <800000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <0>;
 +		};
 +
 +		opp-600000000 {
@@ -88,6 +104,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <850000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-800000000 {
@@ -98,6 +115,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <900000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-1000000000 {
@@ -108,6 +126,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <950000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-1200000000 {
@@ -118,6 +137,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <1000000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-1400000000 {
@@ -128,6 +148,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <1050000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <2>;
 +		};
 +	};
 +
@@ -485,7 +506,7 @@
  		};
  	};
  
-@@ -93,6 +552,15 @@
+@@ -93,6 +570,15 @@
  		};
  	};
  
@@ -501,10 +522,21 @@
  	firmware {
  		scm {
  			compatible = "qcom,scm-ipq806x", "qcom,scm";
-@@ -120,6 +588,84 @@
+@@ -120,6 +606,95 @@
  			reg-names = "lpass-lpaif";
  		};
  
++		L2: l2-cache {
++			compatible = "qcom,krait-cache", "cache";
++			cache-level = <2>;
++			qcom,saw = <&saw_l2>;
++
++			clocks = <&kraitcc 4>;
++			clock-names = "l2";
++			l2-supply = <&smb208_s1a>;
++			operating-points-v2 = <&opp_table_l2>;
++		};
++
 +		qfprom: qfprom@700000 {
 +			compatible = "qcom,qfprom", "syscon";
 +			reg = <0x700000 0x1000>;
@@ -586,7 +618,7 @@
  		qcom_pinmux: pinmux@800000 {
  			compatible = "qcom,ipq8064-pinctrl";
  			reg = <0x800000 0x4000>;
-@@ -159,6 +705,15 @@
+@@ -159,6 +734,15 @@
  				};
  			};
  
@@ -602,7 +634,7 @@
  			spi_pins: spi_pins {
  				mux {
  					pins = "gpio18", "gpio19", "gpio21";
-@@ -168,6 +723,53 @@
+@@ -168,6 +752,53 @@
  				};
  			};
  
@@ -656,7 +688,7 @@
  			leds_pins: leds_pins {
  				mux {
  					pins = "gpio7", "gpio8", "gpio9",
-@@ -229,6 +831,17 @@
+@@ -229,6 +860,17 @@
  			clock-output-names = "acpu1_aux";
  		};
  
@@ -674,7 +706,7 @@
  		saw0: regulator@2089000 {
  			compatible = "qcom,saw2", "qcom,apq8064-saw2-v1.1-cpu", "syscon";
  			reg = <0x02089000 0x1000>, <0x02009000 0x1000>;
-@@ -241,6 +854,17 @@
+@@ -241,6 +883,17 @@
  			regulator;
  		};
  
@@ -692,7 +724,7 @@
  		gsbi2: gsbi@12480000 {
  			compatible = "qcom,gsbi-v1.0.0";
  			cell-index = <2>;
-@@ -436,6 +1060,15 @@
+@@ -436,6 +1089,15 @@
  			#power-domain-cells = <1>;
  		};
  
@@ -708,7 +740,7 @@
  		tcsr: syscon@1a400000 {
  			compatible = "qcom,tcsr-ipq8064", "syscon";
  			reg = <0x1a400000 0x100>;
-@@ -448,6 +1081,95 @@
+@@ -448,6 +1110,95 @@
  			#reset-cells = <1>;
  		};
  
@@ -804,7 +836,7 @@
  		pcie0: pci@1b500000 {
  			compatible = "qcom,pcie-ipq8064";
  			reg = <0x1b500000 0x1000
-@@ -601,6 +1323,167 @@
+@@ -601,6 +1352,167 @@
  			perst-gpio = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
  		};
  
@@ -972,7 +1004,7 @@
  		vsdcc_fixed: vsdcc-regulator {
  			compatible = "regulator-fixed";
  			regulator-name = "SDCC Power";
-@@ -676,4 +1559,17 @@
+@@ -676,4 +1588,17 @@
  			};
  		};
  	};

--- a/target/linux/ipq806x/patches-5.4/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
+++ b/target/linux/ipq806x/patches-5.4/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
@@ -75,7 +75,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  ##################################################################################
 --- /dev/null
 +++ b/drivers/cpufreq/qcom-cpufreq-krait.c
-@@ -0,0 +1,601 @@
+@@ -0,0 +1,603 @@
 +// SPDX-License-Identifier: GPL-2.0
 +
 +#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
@@ -115,9 +115,11 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +	int cpu, ret;
 +
 +	if (l2_pdev) {
++		int policy_cpu = policy->cpu;
++
 +		/* find the max freq across all core */
 +		for_each_present_cpu(cpu)
-+			if (cpu != index)
++			if (cpu != policy_cpu)
 +				target_freq = max(
 +					target_freq,
 +					(unsigned long)cpufreq_quick_get(cpu));
@@ -132,6 +134,18 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		level = dev_pm_opp_get_level(opp);
 +		dev_pm_opp_put(opp);
 +
++		/*
++		 * Hardware constraint:
++		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
++		 * Assume index 0 with the idle freq and level > 0 as 
++		 * any L2 freq > 384MHz.
++		 * Skip CPU freq change in this corner case.
++		 */
++		if (unlikely(index == 0 && level != 0)) {
++			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
++			return -EINVAL;
++		}
++
 +		opp = dev_pm_opp_find_level_exact(&l2_pdev->dev, level);
 +		if (IS_ERR(opp)) {
 +			dev_err(&l2_pdev->dev,
@@ -144,18 +158,6 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		ret = dev_pm_opp_set_rate(&l2_pdev->dev, target_freq);
 +		if (ret)
 +			return ret;
-+
-+		/*
-+		 * Hardware constraint:
-+		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
-+		 * Assume index 0 with the idle freq and level > 0 as 
-+		 * any L2 freq > 384MHz.
-+		 * Skip CPU freq change in this corner case.
-+		 */
-+		if (unlikely(index == 0 && level != 0)) {
-+			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
-+			return -EINVAL;
-+		}
 +	}
 +
 +	ret = dev_pm_opp_set_rate(priv->cpu_dev, freq * 1000);

--- a/target/linux/ipq806x/patches-5.4/098-3-add-fab-scaling-support-with-cpufreq.patch
+++ b/target/linux/ipq806x/patches-5.4/098-3-add-fab-scaling-support-with-cpufreq.patch
@@ -227,9 +227,9 @@
  
  #include "cpufreq-dt.h"
  
-@@ -54,6 +55,13 @@ static int set_target(struct cpufreq_pol
- 		level = dev_pm_opp_get_level(opp);
- 		dev_pm_opp_put(opp);
+@@ -68,6 +69,13 @@ static int set_target(struct cpufreq_pol
+ 			return -EINVAL;
+ 		}
  
 +		/*
 +		 * Scale fabrics with max freq across all cores

--- a/target/linux/ipq806x/patches-5.4/851-add-gsbi1-dts.patch
+++ b/target/linux/ipq806x/patches-5.4/851-add-gsbi1-dts.patch
@@ -1,6 +1,6 @@
 --- a/arch/arm/boot/dts/qcom-ipq8064.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq8064.dtsi
-@@ -865,6 +865,41 @@
+@@ -894,6 +894,41 @@
  			reg = <0x12100000 0x10000>;
  		};
  


### PR DESCRIPTION
* ipq806x: fix missing changes in 5.4 for new cpufreq implementation

The new cpufreq dedicated driver changed the node structure
on how the cache should be defined in the dts. The 5.4 dtsi addition
patch has not been updated to follow the new implementation.
Fix this to restore correct cache scaling and restore any performance
regression.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

* ipq806x: fix missing 1.4ghz cache freq for ipq8065 SoC

With the new implementation of the dedicated cpufreq driver,
the 1.4 Ghz was only dropped and not added to the ipq8065 SoC.
Fix this to improve performance.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

* ipq806x: fix dedicated cpufreq driver

2 small fix for the dedicated cpufreq driver:
- Fix index wrongly used as the current cpu
- Exit early if a bad freq is detected. In the current state the freq
is applied anyway even with invalid state.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

Co-authored-by: Ansuel Smith <ansuelsmth@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
