### PR TITLE
dnsmasq: rework jail mounts (#7578)

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -19,6 +19,7 @@ BASEDHCPSTAMPFILE="/var/run/dnsmasq"
 DHCPBOGUSHOSTNAMEFILE="/usr/share/dnsmasq/dhcpbogushostname.conf"
 RFC6761FILE="/usr/share/dnsmasq/rfc6761.conf"
 DHCPSCRIPT="/usr/lib/dnsmasq/dhcp-script.sh"
+DHCPSCRIPT_DEPENDS="/usr/share/libubox/jshn.sh /usr/bin/jshn /bin/ubus"
 
 DNSMASQ_DHCP_VER=4
 
@@ -187,6 +188,7 @@ append_notinterface() {
 }
 
 append_addnhosts() {
+	append EXTRA_MOUNT "$1"
 	xappend "--addn-hosts=$1"
 }
 
@@ -1123,7 +1125,11 @@ dnsmasq_start()
 	procd_set_param respawn
 
 	procd_add_jail dnsmasq ubus log
-	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE $RFC6761FILE $DHCPBOGUSHOSTNAMEFILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript /etc/hosts /etc/ethers /sbin/hotplug-call $EXTRA_MOUNT $DHCPSCRIPT /tmp/hosts/
+	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE $RFC6761FILE
+	procd_add_jail_mount $EXTRA_MOUNT $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
+	procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
+	procd_add_jail_mount /dev/null /dev/urandom
+	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
 
 	procd_close_instance


### PR DESCRIPTION
* split into multiple lines to improve readability
 * use EXTRA_MOUNT for addnhosts instead of blindly adding /tmp/hosts
 * remove no longer needed mount for /sbin/hotplug-call
 * add dhcp-script.sh dependencies (jshn, ubus)

Fixes: 3a94c2ca5c ("dnsmasq: add /tmp/hosts/ to jail_mount")
Fixes: aed95c4cb8 ("dnsmasq: switch to ubus-based hotplug call")
Reported-by: Stijn Tintel <stijn@linux-ipv6.be>
Signed-off-by: Daniel Golle <daniel@makrotopia.org>

Co-authored-by: Daniel Golle <daniel@makrotopia.org>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
