### PR TITLE
openssl: Refresh patch (#7765)

### DIFF
--- a/package/libs/openssl/patches/410-eng_devcrypto-add-configuration-options.patch
+++ b/package/libs/openssl/patches/410-eng_devcrypto-add-configuration-options.patch
@@ -1,4 +1,4 @@
-From 1c2fabcdb34e436286b4a8760cfbfbff11ea551a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eneas U de Queiroz <cote2004-github@yahoo.com>
 Date: Sat, 3 Nov 2018 15:41:10 -0300
 Subject: eng_devcrypto: add configuration options
@@ -14,7 +14,6 @@ Reviewed-by: Richard Levitte <levitte@openssl.org>
 (Merged from https://github.com/openssl/openssl/pull/7585)
 
 diff --git a/crypto/engine/eng_devcrypto.c b/crypto/engine/eng_devcrypto.c
-index a2c9a966f7..5ec38ca8f3 100644
 --- a/crypto/engine/eng_devcrypto.c
 +++ b/crypto/engine/eng_devcrypto.c
 @@ -16,6 +16,7 @@
@@ -558,7 +557,7 @@ index a2c9a966f7..5ec38ca8f3 100644
  /******************************************************************************
   *
   * LOAD / UNLOAD
-@@ -793,6 +1109,8 @@ void engine_load_devcrypto_int()
+@@ -806,6 +1122,8 @@ void engine_load_devcrypto_int()
  
      if (!ENGINE_set_id(e, "devcrypto")
          || !ENGINE_set_name(e, "/dev/crypto engine")


### PR DESCRIPTION
This version fixes two vulnerabilities:
  - SM2 Decryption Buffer Overflow (CVE-2021-3711)
    Severity: High

  - Read buffer overruns processing ASN.1 strings (CVE-2021-3712)
    Severity: Medium

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Co-authored-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
