### PR TITLE
kernel: add module for  bcm574xx 575xx serials (#8369)

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1120,6 +1120,28 @@ endef
 
 $(eval $(call KernelPackage,bnx2x))
 
+
+define KernelPackage/bnxt-en
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=BCM 574xx/575xx 10/25/50-Gigabit ethernet adapter driver
+  DEPENDS:=@PCI_SUPPORT  +kmod-lib-crc32c +kmod-mdio +kmod-ptp +kmod-lib-zlib-inflate
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/broadcom/bnxt/bnxt_en.ko
+  KCONFIG:= \
+	CONFIG_BNXT \
+	CONFIG_BNXT_SRIOV=y \
+  	CONFIG_BNXT_FLOWER_OFFLOAD=y \
+  	CONFIG_BNXT_DCB=n \
+  	CONFIG_BNXT_HWMON=y
+  AUTOLOAD:=$(call AutoProbe,bnxt_en)
+endef
+
+define KernelPackage/bnxt-en/description
+  Broadcom 573xx/574xx/575xx 10/25/40/50-Gigabit ethernet adapter Driver
+endef
+
+$(eval $(call KernelPackage,bnxt-en))
+
+
 define KernelPackage/be2net
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Broadcom Emulex OneConnect 10Gbps NIC


### PR DESCRIPTION
kernel: add module for bnxt_en Linux driver for the 
Broadcom NetXtreme-C/NetXtreme-E 
BCM573xx, BCM574xx, BCM575xx, NetXtreme-S BCM5880x
(up to 200 Gbps) Ethernet Network Controllers and Broadcom Nitro
BCM58700 4-port 1/2.5/10 Gbps Ethernet Network Controller.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
