### PR TITLE
uboot-rockchip: Fix doornet1dts (#9003)

### DIFF
--- a/package/boot/uboot-rockchip/patches/104-rockchip-rk3328-Add-support-for-EmbedFire-DoorNet1.patch
+++ b/package/boot/uboot-rockchip/patches/104-rockchip-rk3328-Add-support-for-EmbedFire-DoorNet1.patch
@@ -10,11 +10,56 @@
  	rk3328-orangepi-r1-plus.dtb \
 --- /dev/null
 +++ b/arch/arm/dts/rk3328-doornet1-u-boot.dtsi
-@@ -0,0 +1,1 @@
-+#include "rk3328-nanopi-r2s-u-boot.dtsi"
+@@ -0,0 +1,46 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
++ * Copyright (c) 2021 EmbedFire <embedfire@embedfire.com>
++ */
++
++#include "rk3328-u-boot.dtsi"
++#include "rk3328-sdram-ddr4-666.dtsi"
++/ {
++	aliases {
++		mmc0 = &sdmmc;
++		mmc1 = &emmc;
++	};
++
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
++	};
++};
++
++&gpio0 {
++	u-boot,dm-spl;
++};
++
++&pinctrl {
++	u-boot,dm-spl;
++};
++
++&sdmmc0m1_gpio {
++	u-boot,dm-spl;
++};
++
++&pcfg_pull_up_4ma {
++	u-boot,dm-spl;
++};
++
++/* Need this and all the pinctrl/gpio stuff above to set pinmux */
++&vcc_sd {
++	u-boot,dm-spl;
++};
++
++&gmac2io {
++	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++};
++
 --- /dev/null
 +++ b/arch/arm/dts/rk3328-doornet1.dts
-@@ -0,0 +1,370 @@
+@@ -0,0 +1,385 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 David Bauer <mail@david-bauer.net>
@@ -351,6 +396,20 @@
 +	status = "okay";
 +};
 +
++&emmc {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	max-frequency = <150000000>;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++	vmmc-supply = <&vcc_io_33>;
++	vqmmc-supply = <&vcc18_emmc>;
++	status = "okay";
++};
++
 +&tsadc {
 +	rockchip,hw-tshut-mode = <0>;
 +	rockchip,hw-tshut-polarity = <0>;
@@ -385,6 +444,7 @@
 +&usb_host0_ohci {
 +	status = "okay";
 +};
++
 --- /dev/null
 +++ b/configs/doornet1-rk3328_defconfig
 @@ -0,0 +1,98 @@
@@ -486,6 +546,20 @@
 +CONFIG_SPL_TINY_MEMSET=y
 +CONFIG_TPL_TINY_MEMSET=y
 +CONFIG_ERRNO_STR=y
+
+--- a/arch/arm/mach-rockchip/rk3328/rk3328.c
++++ b/arch/arm/mach-rockchip/rk3328/rk3328.c
+@@ -21,8 +21,8 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define FW_DDR_CON_REG		0xFF7C0040
+ 
+ const char * const boot_devices[BROM_LAST_BOOTSOURCE + 1] = {
+-	[BROM_BOOTSOURCE_EMMC] = "/rksdmmc@ff520000",
+-	[BROM_BOOTSOURCE_SD] = "/rksdmmc@ff500000",
++	[BROM_BOOTSOURCE_SD] = "/mmc@ff500000",
++	[BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",
+ };
+ 
+ static struct mm_region rk3328_mem_map[] = {
 --- a/board/rockchip/evb_rk3328/MAINTAINERS
 +++ b/board/rockchip/evb_rk3328/MAINTAINERS
 @@ -1,3 +1,10 @@


### PR DESCRIPTION
* uboot-rockchip: Fix doornet1dts

The dts refers to the official website uboot startup parameters
`arch/arm/mach-rockchip/rk3328/rk3328.c`---Fix boot order parameters,It is helpful for other devices to start emmc and sd normally

* Update 104-rockchip-rk3328-Add-support-for-EmbedFire-DoorNet1.patch

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
