### PR TITLE
mac80211: backport security fixes (#10324)

### DIFF
--- a/package/kernel/mac80211/patches/ath10k/991-ath10k-5.19.patch
+++ b/package/kernel/mac80211/patches/ath10k/991-ath10k-5.19.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
-@@ -3333,7 +3333,11 @@
+@@ -3333,7 +3333,11 @@ static int ath10k_core_probe_fw(struct a
  		ath10k_debug_print_board_info(ar);
  	}
  

--- a/package/kernel/mac80211/patches/brcm/999-backport-to-linux-5.18.patch
+++ b/package/kernel/mac80211/patches/brcm/999-backport-to-linux-5.18.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c
-index 44a11b0..178e692 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c
-@@ -245,7 +245,11 @@
+@@ -245,7 +245,11 @@ static int brcmf_netdev_set_mac_address(
  	} else {
  		brcmf_dbg(TRACE, "updated to %pM\n", sa->sa_data);
  		memcpy(ifp->mac_addr, sa->sa_data, ETH_ALEN);
@@ -14,15 +12,15 @@ index 44a11b0..178e692 100644
  	}
  	return err;
  }
-@@ -424,6 +428,7 @@
+@@ -424,6 +428,7 @@ void brcmf_netif_rx(struct brcmf_if *ifp
  	ifp->ndev->stats.rx_packets++;
-
+ 
  	brcmf_dbg(DATA, "rx proto=0x%X\n", ntohs(skb->protocol));
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
  	if (inirq) {
  		netif_rx(skb);
  	} else {
-@@ -433,6 +438,9 @@
+@@ -433,6 +438,9 @@ void brcmf_netif_rx(struct brcmf_if *ifp
  		 */
  		netif_rx_ni(skb);
  	}
@@ -30,11 +28,11 @@ index 44a11b0..178e692 100644
 +	netif_rx(skb);
 +#endif
  }
-
+ 
  void brcmf_netif_mon_rx(struct brcmf_if *ifp, struct sk_buff *skb)
-@@ -673,7 +681,11 @@
+@@ -673,7 +681,11 @@ int brcmf_net_attach(struct brcmf_if *if
  	ndev->ethtool_ops = &brcmf_ethtool_ops;
-
+ 
  	/* set the mac address & netns */
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
  	memcpy(ndev->dev_addr, ifp->mac_addr, ETH_ALEN);
@@ -42,25 +40,23 @@ index 44a11b0..178e692 100644
 +	eth_hw_addr_set(ifp->ndev, ifp->mac_addr);
 +#endif
  	dev_net_set(ndev, wiphy_net(cfg_to_wiphy(drvr->config)));
-
+ 
  	INIT_WORK(&ifp->multicast_work, _brcmf_set_multicast_list);
-@@ -848,7 +860,11 @@
+@@ -848,7 +860,11 @@ static int brcmf_net_p2p_attach(struct b
  	ndev->netdev_ops = &brcmf_netdev_ops_p2p;
-
+ 
  	/* set the mac address */
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
  	memcpy(ndev->dev_addr, ifp->mac_addr, ETH_ALEN);
 +#else
 +	eth_hw_addr_set(ndev, ifp->mac_addr);
 +#endif
-
+ 
  	if (register_netdev(ndev) != 0) {
  		bphy_err(drvr, "couldn't register the p2p net device\n");
-diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
-index 9ac0d8c..4735063 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
-@@ -2125,7 +2125,7 @@ static int brcmf_p2p_disable_p2p_if(struct brcmf_cfg80211_vif *vif)
+@@ -2125,7 +2125,7 @@ static int brcmf_p2p_disable_p2p_if(stru
  	struct brcmf_cfg80211_info *cfg = wdev_to_cfg(&vif->wdev);
  	struct net_device *pri_ndev = cfg_to_ndev(cfg);
  	struct brcmf_if *ifp = netdev_priv(pri_ndev);
@@ -69,7 +65,7 @@ index 9ac0d8c..4735063 100644
  
  	return brcmf_fil_iovar_data_set(ifp, "p2p_ifdis", addr, ETH_ALEN);
  }
-@@ -2135,7 +2135,7 @@ static int brcmf_p2p_release_p2p_if(struct brcmf_cfg80211_vif *vif)
+@@ -2135,7 +2135,7 @@ static int brcmf_p2p_release_p2p_if(stru
  	struct brcmf_cfg80211_info *cfg = wdev_to_cfg(&vif->wdev);
  	struct net_device *pri_ndev = cfg_to_ndev(cfg);
  	struct brcmf_if *ifp = netdev_priv(pri_ndev);
@@ -78,11 +74,9 @@ index 9ac0d8c..4735063 100644
  
  	return brcmf_fil_iovar_data_set(ifp, "p2p_ifdel", addr, ETH_ALEN);
  }
-diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
-index 8effeb7..04362e2 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
-@@ -4164,7 +4164,11 @@
+@@ -4164,7 +4164,11 @@ static int brcmf_sdio_bus_reset(struct d
  
  	/* reset the adapter */
  	sdio_claim_host(sdiodev->func1);
@@ -94,8 +88,6 @@ index 8effeb7..04362e2 100644
  	sdio_release_host(sdiodev->func1);
  
  	brcmf_bus_change_state(sdiodev->bus_if, BRCMF_BUS_DOWN);
-diff --git a/include/net/cfg80211.h b/include/net/cfg80211.h
-index ab83553..7941d28 100644
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
 @@ -5555,7 +5555,7 @@ struct wireless_dev {
@@ -107,11 +99,9 @@ index ab83553..7941d28 100644
  {
  	if (wdev->netdev)
  		return wdev->netdev->dev_addr;
-diff --git a/net/mac80211/iface.c b/net/mac80211/iface.c
-index 57aa863..f5ebb5a 100644
 --- a/net/mac80211/iface.c
 +++ b/net/mac80211/iface.c
-@@ -1274,9 +1274,13 @@
+@@ -1274,9 +1274,13 @@ int ieee80211_do_open(struct wireless_de
  	 * this interface, if it has the special null one.
  	 */
  	if (dev && is_zero_ether_addr(dev->dev_addr)) {
@@ -123,10 +113,10 @@ index 57aa863..f5ebb5a 100644
 +		eth_hw_addr_set(dev, local->hw.wiphy->perm_addr);
 +#endif
  		memcpy(dev->perm_addr, dev->dev_addr, ETH_ALEN);
-
+ 
  		if (!is_valid_ether_addr(dev->dev_addr)) {
-@@ -2136,9 +2140,17 @@
-
+@@ -2136,9 +2140,17 @@ int ieee80211_if_add(struct ieee80211_lo
+ 
  		ieee80211_assign_perm_addr(local, ndev->perm_addr, type);
  		if (is_valid_ether_addr(params->macaddr))
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
@@ -141,5 +131,5 @@ index 57aa863..f5ebb5a 100644
 +			eth_hw_addr_set(ndev, ndev->perm_addr);
 +#endif
  		SET_NETDEV_DEV(ndev, wiphy_dev(local->hw.wiphy));
-
+ 
  		/* don't use IEEE80211_DEV_TO_SUB_IF -- it checks too much */

--- a/package/kernel/mac80211/patches/build/267-rtl8723_5.18_support.patch
+++ b/package/kernel/mac80211/patches/build/267-rtl8723_5.18_support.patch
@@ -1,5 +1,5 @@
 --- a/drivers/staging/rtl8723bs/include/osdep_service_linux.h
-+++ a/drivers/staging/rtl8723bs/include/osdep_service_linux.h
++++ b/drivers/staging/rtl8723bs/include/osdep_service_linux.h
 @@ -45,7 +45,11 @@
  		spinlock_t	lock;
  	};

--- a/package/kernel/mac80211/patches/build/882-use-netif_rx.patch
+++ b/package/kernel/mac80211/patches/build/882-use-netif_rx.patch
@@ -1,6 +1,6 @@
 --- a/net/wireless/util.c
 +++ b/net/wireless/util.c
-@@ -2149,7 +2149,11 @@
+@@ -2149,7 +2149,11 @@ void cfg80211_send_layer2_update(struct
  	skb->dev = dev;
  	skb->protocol = eth_type_trans(skb, dev);
  	memset(skb->cb, 0, sizeof(skb->cb));

--- a/package/kernel/mac80211/patches/rt2x00/999-backport-to-linux-5.18.patch
+++ b/package/kernel/mac80211/patches/rt2x00/999-backport-to-linux-5.18.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/wireless/ralink/rt2x00/rt2x00usb.c
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00usb.c
-@@ -586,10 +586,18 @@ static void rt2x00usb_assign_endpoint(struct data_queue *queue,
+@@ -586,10 +586,18 @@ static void rt2x00usb_assign_endpoint(st
  
  	if (queue->qid == QID_RX) {
  		pipe = usb_rcvbulkpipe(usb_dev, queue->usb_endpoint);

--- a/package/kernel/mac80211/patches/rtl/001-rtw88-Call-rtw_fw_beacon_filter_config-with-rtwdev--mutex-held.patch
+++ b/package/kernel/mac80211/patches/rtl/001-rtw88-Call-rtw_fw_beacon_filter_config-with-rtwdev--mutex-held.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireless/realtek/rtw88/mac80211.c
-index 5cdc54c9a9aae..3c07485d6ba47 100644
 --- a/drivers/net/wireless/realtek/rtw88/mac80211.c
 +++ b/drivers/net/wireless/realtek/rtw88/mac80211.c
-@@ -466,8 +466,8 @@ static int rtw_ops_sta_remove(struct ieee80211_hw *hw,
+@@ -455,8 +455,8 @@ static int rtw_ops_sta_remove(struct iee
  {
  	struct rtw_dev *rtwdev = hw->priv;
  

--- a/package/kernel/mac80211/patches/rtl/002-rtw88-Drop-rf_lock.patch
+++ b/package/kernel/mac80211/patches/rtl/002-rtw88-Drop-rf_lock.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/debug.c b/drivers/net/wireless/realtek/rtw88/debug.c
-index 1a52ff585fbc7..ba5ba852efb8c 100644
 --- a/drivers/net/wireless/realtek/rtw88/debug.c
 +++ b/drivers/net/wireless/realtek/rtw88/debug.c
-@@ -144,7 +144,9 @@ static int rtw_debugfs_get_rf_read(struct seq_file *m, void *v)
+@@ -143,7 +143,9 @@ static int rtw_debugfs_get_rf_read(struc
  	addr = debugfs_priv->rf_addr;
  	mask = debugfs_priv->rf_mask;
  
@@ -12,7 +10,7 @@ index 1a52ff585fbc7..ba5ba852efb8c 100644
  
  	seq_printf(m, "rf_read path:%d addr:0x%08x mask:0x%08x val=0x%08x\n",
  		   path, addr, mask, val);
-@@ -418,7 +420,9 @@ static ssize_t rtw_debugfs_set_rf_write(struct file *filp,
+@@ -401,7 +403,9 @@ static ssize_t rtw_debugfs_set_rf_write(
  		return count;
  	}
  
@@ -22,7 +20,7 @@ index 1a52ff585fbc7..ba5ba852efb8c 100644
  	rtw_dbg(rtwdev, RTW_DBG_DEBUGFS,
  		"write_rf path:%d addr:0x%08x mask:0x%08x, val:0x%08x\n",
  		path, addr, mask, val);
-@@ -523,6 +527,8 @@ static int rtw_debug_get_rf_dump(struct seq_file *m, void *v)
+@@ -481,6 +485,8 @@ static int rtw_debug_get_rf_dump(struct
  	u32 addr, offset, data;
  	u8 path;
  
@@ -31,7 +29,7 @@ index 1a52ff585fbc7..ba5ba852efb8c 100644
  	for (path = 0; path < rtwdev->hal.rf_path_num; path++) {
  		seq_printf(m, "RF path:%d\n", path);
  		for (addr = 0; addr < 0x100; addr += 4) {
-@@ -537,6 +543,8 @@ static int rtw_debug_get_rf_dump(struct seq_file *m, void *v)
+@@ -495,6 +501,8 @@ static int rtw_debug_get_rf_dump(struct
  		seq_puts(m, "\n");
  	}
  
@@ -40,7 +38,7 @@ index 1a52ff585fbc7..ba5ba852efb8c 100644
  	return 0;
  }
  
-@@ -1027,6 +1035,8 @@ static void dump_gapk_status(struct rtw_dev *rtwdev, struct seq_file *m)
+@@ -911,6 +919,8 @@ static void dump_gapk_status(struct rtw_
  		   dm_info->dm_flags & BIT(RTW_DM_CAP_TXGAPK) ? '-' : '+',
  		   rtw_dm_cap_strs[RTW_DM_CAP_TXGAPK]);
  
@@ -49,7 +47,7 @@ index 1a52ff585fbc7..ba5ba852efb8c 100644
  	for (path = 0; path < rtwdev->hal.rf_path_num; path++) {
  		val = rtw_read_rf(rtwdev, path, RF_GAINTX, RFREG_MASK);
  		seq_printf(m, "path %d:\n0x%x = 0x%x\n", path, RF_GAINTX, val);
-@@ -1036,6 +1046,7 @@ static void dump_gapk_status(struct rtw_dev *rtwdev, struct seq_file *m)
+@@ -920,6 +930,7 @@ static void dump_gapk_status(struct rtw_
  				   txgapk->rf3f_fs[path][i], i);
  		seq_puts(m, "\n");
  	}
@@ -57,8 +55,6 @@ index 1a52ff585fbc7..ba5ba852efb8c 100644
  }
  
  static int rtw_debugfs_get_dm_cap(struct seq_file *m, void *v)
-diff --git a/drivers/net/wireless/realtek/rtw88/hci.h b/drivers/net/wireless/realtek/rtw88/hci.h
-index 4c6fc6fb3f83b..830d7532f2a35 100644
 --- a/drivers/net/wireless/realtek/rtw88/hci.h
 +++ b/drivers/net/wireless/realtek/rtw88/hci.h
 @@ -166,12 +166,11 @@ static inline u32
@@ -89,11 +85,9 @@ index 4c6fc6fb3f83b..830d7532f2a35 100644
  }
  
  static inline u32
-diff --git a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
-index 8b9899e41b0bb..f9864840ffd9c 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.c
 +++ b/drivers/net/wireless/realtek/rtw88/main.c
-@@ -1994,7 +1994,6 @@ int rtw_core_init(struct rtw_dev *rtwdev)
+@@ -1839,7 +1839,6 @@ int rtw_core_init(struct rtw_dev *rtwdev
  	skb_queue_head_init(&rtwdev->coex.queue);
  	skb_queue_head_init(&rtwdev->tx_report.queue);
  
@@ -101,11 +95,9 @@ index 8b9899e41b0bb..f9864840ffd9c 100644
  	spin_lock_init(&rtwdev->h2c.lock);
  	spin_lock_init(&rtwdev->txq_lock);
  	spin_lock_init(&rtwdev->tx_report.q_lock);
-diff --git a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
-index 17815af9dd4ea..df6c6032bbd3b 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.h
 +++ b/drivers/net/wireless/realtek/rtw88/main.h
-@@ -1994,9 +1994,6 @@ struct rtw_dev {
+@@ -1842,9 +1842,6 @@ struct rtw_dev {
  	/* ensures exclusive access from mac80211 callbacks */
  	struct mutex mutex;
  

--- a/package/kernel/mac80211/patches/rtl/003-rtw88-Drop-h2c.lock.patch
+++ b/package/kernel/mac80211/patches/rtl/003-rtw88-Drop-h2c.lock.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/debug.c b/drivers/net/wireless/realtek/rtw88/debug.c
-index ba5ba852efb8c..79939aa6b752c 100644
 --- a/drivers/net/wireless/realtek/rtw88/debug.c
 +++ b/drivers/net/wireless/realtek/rtw88/debug.c
-@@ -396,7 +396,9 @@ static ssize_t rtw_debugfs_set_h2c(struct file *filp,
+@@ -379,7 +379,9 @@ static ssize_t rtw_debugfs_set_h2c(struc
  		return -EINVAL;
  	}
  
@@ -12,11 +10,9 @@ index ba5ba852efb8c..79939aa6b752c 100644
  
  	return count;
  }
-diff --git a/drivers/net/wireless/realtek/rtw88/fw.c b/drivers/net/wireless/realtek/rtw88/fw.c
-index aa2aeb5fb2ccd..c3ad2a1b47212 100644
 --- a/drivers/net/wireless/realtek/rtw88/fw.c
 +++ b/drivers/net/wireless/realtek/rtw88/fw.c
-@@ -320,7 +320,7 @@ static void rtw_fw_send_h2c_command(struct rtw_dev *rtwdev,
+@@ -285,7 +285,7 @@ static void rtw_fw_send_h2c_command(stru
  		h2c[3], h2c[2], h2c[1], h2c[0],
  		h2c[7], h2c[6], h2c[5], h2c[4]);
  
@@ -25,7 +21,7 @@ index aa2aeb5fb2ccd..c3ad2a1b47212 100644
  
  	box = rtwdev->h2c.last_box_num;
  	switch (box) {
-@@ -342,7 +342,7 @@ static void rtw_fw_send_h2c_command(struct rtw_dev *rtwdev,
+@@ -307,7 +307,7 @@ static void rtw_fw_send_h2c_command(stru
  		break;
  	default:
  		WARN(1, "invalid h2c mail box number\n");
@@ -34,7 +30,7 @@ index aa2aeb5fb2ccd..c3ad2a1b47212 100644
  	}
  
  	ret = read_poll_timeout_atomic(rtw_read8, box_state,
-@@ -351,7 +351,7 @@ static void rtw_fw_send_h2c_command(struct rtw_dev *rtwdev,
+@@ -316,7 +316,7 @@ static void rtw_fw_send_h2c_command(stru
  
  	if (ret) {
  		rtw_err(rtwdev, "failed to send h2c command\n");
@@ -43,7 +39,7 @@ index aa2aeb5fb2ccd..c3ad2a1b47212 100644
  	}
  
  	for (idx = 0; idx < 4; idx++)
-@@ -361,9 +361,6 @@ static void rtw_fw_send_h2c_command(struct rtw_dev *rtwdev,
+@@ -326,9 +326,6 @@ static void rtw_fw_send_h2c_command(stru
  
  	if (++rtwdev->h2c.last_box_num >= 4)
  		rtwdev->h2c.last_box_num = 0;
@@ -53,7 +49,7 @@ index aa2aeb5fb2ccd..c3ad2a1b47212 100644
  }
  
  void rtw_fw_h2c_cmd_dbg(struct rtw_dev *rtwdev, u8 *h2c)
-@@ -375,15 +372,13 @@ static void rtw_fw_send_h2c_packet(struct rtw_dev *rtwdev, u8 *h2c_pkt)
+@@ -340,15 +337,13 @@ static void rtw_fw_send_h2c_packet(struc
  {
  	int ret;
  
@@ -70,11 +66,9 @@ index aa2aeb5fb2ccd..c3ad2a1b47212 100644
  }
  
  void
-diff --git a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
-index f9864840ffd9c..baf4d29fde678 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.c
 +++ b/drivers/net/wireless/realtek/rtw88/main.c
-@@ -1994,7 +1994,6 @@ int rtw_core_init(struct rtw_dev *rtwdev)
+@@ -1839,7 +1839,6 @@ int rtw_core_init(struct rtw_dev *rtwdev
  	skb_queue_head_init(&rtwdev->coex.queue);
  	skb_queue_head_init(&rtwdev->tx_report.queue);
  
@@ -82,11 +76,9 @@ index f9864840ffd9c..baf4d29fde678 100644
  	spin_lock_init(&rtwdev->txq_lock);
  	spin_lock_init(&rtwdev->tx_report.q_lock);
  
-diff --git a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
-index df6c6032bbd3b..619ee6e8d2807 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.h
 +++ b/drivers/net/wireless/realtek/rtw88/main.h
-@@ -2018,8 +2018,6 @@ struct rtw_dev {
+@@ -1865,8 +1865,6 @@ struct rtw_dev {
  	struct {
  		/* incicate the mail box to use with fw */
  		u8 last_box_num;

--- a/package/kernel/mac80211/patches/rtl/004-rtw88-Drop-coex-mutex.patch
+++ b/package/kernel/mac80211/patches/rtl/004-rtw88-Drop-coex-mutex.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/coex.c b/drivers/net/wireless/realtek/rtw88/coex.c
-index cac053f485c3b..b156f8c48ffbb 100644
 --- a/drivers/net/wireless/realtek/rtw88/coex.c
 +++ b/drivers/net/wireless/realtek/rtw88/coex.c
-@@ -633,7 +633,7 @@ static struct sk_buff *rtw_coex_info_request(struct rtw_dev *rtwdev,
+@@ -606,7 +606,7 @@ static struct sk_buff *rtw_coex_info_req
  	struct rtw_coex *coex = &rtwdev->coex;
  	struct sk_buff *skb_resp = NULL;
  
@@ -11,7 +9,7 @@ index cac053f485c3b..b156f8c48ffbb 100644
  
  	rtw_fw_query_bt_mp_info(rtwdev, req);
  
-@@ -650,7 +650,6 @@ static struct sk_buff *rtw_coex_info_request(struct rtw_dev *rtwdev,
+@@ -623,7 +623,6 @@ static struct sk_buff *rtw_coex_info_req
  	}
  
  out:
@@ -19,11 +17,9 @@ index cac053f485c3b..b156f8c48ffbb 100644
  	return skb_resp;
  }
  
-diff --git a/drivers/net/wireless/realtek/rtw88/debug.c b/drivers/net/wireless/realtek/rtw88/debug.c
-index 79939aa6b752c..1453a32ea3ef0 100644
 --- a/drivers/net/wireless/realtek/rtw88/debug.c
 +++ b/drivers/net/wireless/realtek/rtw88/debug.c
-@@ -842,7 +842,9 @@ static int rtw_debugfs_get_coex_info(struct seq_file *m, void *v)
+@@ -794,7 +794,9 @@ static int rtw_debugfs_get_coex_info(str
  	struct rtw_debugfs_priv *debugfs_priv = m->private;
  	struct rtw_dev *rtwdev = debugfs_priv->rtwdev;
  
@@ -33,11 +29,9 @@ index 79939aa6b752c..1453a32ea3ef0 100644
  
  	return 0;
  }
-diff --git a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
-index baf4d29fde678..5afb8bef9696a 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.c
 +++ b/drivers/net/wireless/realtek/rtw88/main.c
-@@ -1998,7 +1998,6 @@ int rtw_core_init(struct rtw_dev *rtwdev)
+@@ -1843,7 +1843,6 @@ int rtw_core_init(struct rtw_dev *rtwdev
  	spin_lock_init(&rtwdev->tx_report.q_lock);
  
  	mutex_init(&rtwdev->mutex);
@@ -45,7 +39,7 @@ index baf4d29fde678..5afb8bef9696a 100644
  	mutex_init(&rtwdev->hal.tx_power_mutex);
  
  	init_waitqueue_head(&rtwdev->coex.wait);
-@@ -2066,7 +2065,6 @@ void rtw_core_deinit(struct rtw_dev *rtwdev)
+@@ -1910,7 +1909,6 @@ void rtw_core_deinit(struct rtw_dev *rtw
  	}
  
  	mutex_destroy(&rtwdev->mutex);
@@ -53,11 +47,9 @@ index baf4d29fde678..5afb8bef9696a 100644
  	mutex_destroy(&rtwdev->hal.tx_power_mutex);
  }
  EXPORT_SYMBOL(rtw_core_deinit);
-diff --git a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
-index 619ee6e8d2807..fc27066a67a72 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.h
 +++ b/drivers/net/wireless/realtek/rtw88/main.h
-@@ -1507,8 +1507,6 @@ struct rtw_coex_stat {
+@@ -1429,8 +1429,6 @@ struct rtw_coex_stat {
  };
  
  struct rtw_coex {

--- a/package/kernel/mac80211/patches/rtl/005-rtw88-iterate-over-vif-sta-list-non-atomically.patch
+++ b/package/kernel/mac80211/patches/rtl/005-rtw88-iterate-over-vif-sta-list-non-atomically.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/phy.c b/drivers/net/wireless/realtek/rtw88/phy.c
-index e505d17f107e4..5521a7c2c1afe 100644
 --- a/drivers/net/wireless/realtek/rtw88/phy.c
 +++ b/drivers/net/wireless/realtek/rtw88/phy.c
-@@ -300,7 +300,7 @@ static void rtw_phy_stat_rssi(struct rtw_dev *rtwdev)
+@@ -240,7 +240,7 @@ static void rtw_phy_stat_rssi(struct rtw
  
  	data.rtwdev = rtwdev;
  	data.min_rssi = U8_MAX;
@@ -11,7 +9,7 @@ index e505d17f107e4..5521a7c2c1afe 100644
  
  	dm_info->pre_min_rssi = dm_info->min_rssi;
  	dm_info->min_rssi = data.min_rssi;
-@@ -544,7 +544,7 @@ static void rtw_phy_ra_info_update(struct rtw_dev *rtwdev)
+@@ -484,7 +484,7 @@ static void rtw_phy_ra_info_update(struc
  	if (rtwdev->watch_dog_cnt & 0x3)
  		return;
  
@@ -20,7 +18,7 @@ index e505d17f107e4..5521a7c2c1afe 100644
  }
  
  static u32 rtw_phy_get_rrsr_mask(struct rtw_dev *rtwdev, u8 rate_idx)
-@@ -597,7 +597,7 @@ static void rtw_phy_rrsr_update(struct rtw_dev *rtwdev)
+@@ -537,7 +537,7 @@ static void rtw_phy_rrsr_update(struct r
  	struct rtw_dm_info *dm_info = &rtwdev->dm_info;
  
  	dm_info->rrsr_mask_min = RRSR_RATE_ORDER_MAX;
@@ -29,11 +27,9 @@ index e505d17f107e4..5521a7c2c1afe 100644
  	rtw_write32(rtwdev, REG_RRSR, dm_info->rrsr_val_init & dm_info->rrsr_mask_min);
  }
  
-diff --git a/drivers/net/wireless/realtek/rtw88/ps.c b/drivers/net/wireless/realtek/rtw88/ps.c
-index bfa64c038f5f0..a7213ff2c2244 100644
 --- a/drivers/net/wireless/realtek/rtw88/ps.c
 +++ b/drivers/net/wireless/realtek/rtw88/ps.c
-@@ -58,7 +58,7 @@ int rtw_leave_ips(struct rtw_dev *rtwdev)
+@@ -58,7 +58,7 @@ int rtw_leave_ips(struct rtw_dev *rtwdev
  		return ret;
  	}
  
@@ -42,11 +38,9 @@ index bfa64c038f5f0..a7213ff2c2244 100644
  
  	rtw_coex_ips_notify(rtwdev, COEX_IPS_LEAVE);
  
-diff --git a/drivers/net/wireless/realtek/rtw88/util.c b/drivers/net/wireless/realtek/rtw88/util.c
-index 2c515af214e76..ed61c962fa27f 100644
 --- a/drivers/net/wireless/realtek/rtw88/util.c
 +++ b/drivers/net/wireless/realtek/rtw88/util.c
-@@ -105,3 +105,106 @@ void rtw_desc_to_mcsrate(u16 rate, u8 *mcs, u8 *nss)
+@@ -105,3 +105,106 @@ void rtw_desc_to_mcsrate(u16 rate, u8 *m
  		*mcs = rate - DESC_RATEMCS0;
  	}
  }
@@ -153,8 +147,6 @@ index 2c515af214e76..ed61c962fa27f 100644
 +		kfree(vif_entry);
 +	}
 +}
-diff --git a/drivers/net/wireless/realtek/rtw88/util.h b/drivers/net/wireless/realtek/rtw88/util.h
-index 0c23b5069be0b..dc89655254002 100644
 --- a/drivers/net/wireless/realtek/rtw88/util.h
 +++ b/drivers/net/wireless/realtek/rtw88/util.h
 @@ -7,9 +7,6 @@

--- a/package/kernel/mac80211/patches/rtl/006-rtw88-Add-common-USB-chip-support.patch
+++ b/package/kernel/mac80211/patches/rtl/006-rtw88-Add-common-USB-chip-support.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/Kconfig b/drivers/net/wireless/realtek/rtw88/Kconfig
-index e3d7cb6c12902..1624c5db69bac 100644
 --- a/drivers/net/wireless/realtek/rtw88/Kconfig
 +++ b/drivers/net/wireless/realtek/rtw88/Kconfig
-@@ -19,6 +19,10 @@
+@@ -19,6 +19,10 @@ config RTW88_PCI
  	tristate
  	depends on m
  
@@ -13,22 +11,18 @@ index e3d7cb6c12902..1624c5db69bac 100644
  config RTW88_8822B
  	tristate
  	depends on m
-diff --git a/drivers/net/wireless/realtek/rtw88/Makefile b/drivers/net/wireless/realtek/rtw88/Makefile
-index 834c66ec0af9e..9e095f8181483 100644
 --- a/drivers/net/wireless/realtek/rtw88/Makefile
 +++ b/drivers/net/wireless/realtek/rtw88/Makefile
-@@ -45,3 +45,6 @@
+@@ -45,3 +45,6 @@ rtw88_8821ce-objs		:= rtw8821ce.o
  
  obj-$(CPTCFG_RTW88_PCI)		+= rtw88_pci.o
  rtw88_pci-objs			:= pci.o
 +
 +obj-$(CPTCFG_RTW88_USB)		+= rtw88_usb.o
 +rtw88_usb-objs			:= usb.o
-diff --git a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/realtek/rtw88/mac.c
-index d1678aed9d9cb..19728c705eaa9 100644
 --- a/drivers/net/wireless/realtek/rtw88/mac.c
 +++ b/drivers/net/wireless/realtek/rtw88/mac.c
-@@ -1032,6 +1032,9 @@ static int txdma_queue_mapping(struct rtw_dev *rtwdev)
+@@ -1032,6 +1032,9 @@ static int txdma_queue_mapping(struct rt
  	if (rtw_chip_wcpu_11ac(rtwdev))
  		rtw_write32(rtwdev, REG_H2CQ_CSR, BIT_H2CQ_FULL);
  
@@ -38,11 +32,9 @@ index d1678aed9d9cb..19728c705eaa9 100644
  	return 0;
  }
  
-diff --git a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
-index 5afb8bef9696a..c191260e67a79 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.c
 +++ b/drivers/net/wireless/realtek/rtw88/main.c
-@@ -1715,6 +1715,10 @@ static int rtw_chip_parameter_setup(struct rtw_dev *rtwdev)
+@@ -1561,6 +1561,10 @@ static int rtw_chip_parameter_setup(stru
  		rtwdev->hci.rpwm_addr = 0x03d9;
  		rtwdev->hci.cpwm_addr = 0x03da;
  		break;
@@ -53,11 +45,9 @@ index 5afb8bef9696a..c191260e67a79 100644
  	default:
  		rtw_err(rtwdev, "unsupported hci type\n");
  		return -EINVAL;
-diff --git a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
-index fc27066a67a72..007da6df088a3 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.h
 +++ b/drivers/net/wireless/realtek/rtw88/main.h
-@@ -845,6 +845,10 @@
+@@ -845,6 +845,10 @@ struct rtw_chip_ops {
  			       enum rtw_bb_path tx_path_1ss,
  			       enum rtw_bb_path tx_path_cck,
  			       bool is_tx2_path);
@@ -68,8 +58,6 @@ index fc27066a67a72..007da6df088a3 100644
  
  	/* for coex */
  	void (*coex_set_init)(struct rtw_dev *rtwdev);
-diff --git a/drivers/net/wireless/realtek/rtw88/reg.h b/drivers/net/wireless/realtek/rtw88/reg.h
-index 84ba9ec489c37..a928899030863 100644
 --- a/drivers/net/wireless/realtek/rtw88/reg.h
 +++ b/drivers/net/wireless/realtek/rtw88/reg.h
 @@ -184,6 +184,7 @@
@@ -80,8 +68,6 @@ index 84ba9ec489c37..a928899030863 100644
  #define BIT_SHIFT_TXDMA_BEQ_MAP	8
  #define BIT_MASK_TXDMA_BEQ_MAP	0x3
  #define BIT_TXDMA_BEQ_MAP(x)                                                   \
-diff --git a/drivers/net/wireless/realtek/rtw88/tx.h b/drivers/net/wireless/realtek/rtw88/tx.h
-index 56371eff9f7ff..f900d7c08c84c 100644
 --- a/drivers/net/wireless/realtek/rtw88/tx.h
 +++ b/drivers/net/wireless/realtek/rtw88/tx.h
 @@ -67,6 +67,14 @@
@@ -99,7 +85,7 @@ index 56371eff9f7ff..f900d7c08c84c 100644
  
  enum rtw_tx_desc_queue_select {
  	TX_DESC_QSEL_TID0	= 0,
-@@ -119,4 +127,27 @@ rtw_tx_write_data_h2c_get(struct rtw_dev *rtwdev,
+@@ -119,4 +127,27 @@ rtw_tx_write_data_h2c_get(struct rtw_dev
  			  struct rtw_tx_pkt_info *pkt_info,
  			  u8 *buf, u32 size);
  
@@ -127,9 +113,6 @@ index 56371eff9f7ff..f900d7c08c84c 100644
 +}
 +
  #endif
-diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
-new file mode 100644
-index 0000000000000..500d5208086dd
 --- /dev/null
 +++ b/drivers/net/wireless/realtek/rtw88/usb.c
 @@ -0,0 +1,1037 @@
@@ -1170,9 +1153,6 @@ index 0000000000000..500d5208086dd
 +MODULE_AUTHOR("Realtek Corporation");
 +MODULE_DESCRIPTION("Realtek 802.11ac wireless USB driver");
 +MODULE_LICENSE("Dual BSD/GPL");
-diff --git a/drivers/net/wireless/realtek/rtw88/usb.h b/drivers/net/wireless/realtek/rtw88/usb.h
-new file mode 100644
-index 0000000000000..0e219150ee87a
 --- /dev/null
 +++ b/drivers/net/wireless/realtek/rtw88/usb.h
 @@ -0,0 +1,114 @@
@@ -1290,8 +1270,6 @@ index 0000000000000..0e219150ee87a
 +void rtw_usb_disconnect(struct usb_interface *intf);
 +
 +#endif
-diff --git a/drivers/net/wireless/realtek/rtw88/util.c b/drivers/net/wireless/realtek/rtw88/util.c
-index ed61c962fa27f..ce983ab8f947b 100644
 --- a/drivers/net/wireless/realtek/rtw88/util.c
 +++ b/drivers/net/wireless/realtek/rtw88/util.c
 @@ -167,7 +167,7 @@ struct rtw_iter_vifs_data {

--- a/package/kernel/mac80211/patches/rtl/007-rtw88-Add-rtw8821cu-chipset-support.patch
+++ b/package/kernel/mac80211/patches/rtl/007-rtw88-Add-rtw8821cu-chipset-support.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/Kconfig b/drivers/net/wireless/realtek/rtw88/Kconfig
-index 1624c5db69bac..2b500dbefbc2d 100644
 --- a/drivers/net/wireless/realtek/rtw88/Kconfig
 +++ b/drivers/net/wireless/realtek/rtw88/Kconfig
-@@ -75,6 +75,18 @@ config RTW88_8821CE
+@@ -87,6 +87,18 @@ config RTW88_8821CE
  
  	  802.11ac PCIe wireless network adapter
  
@@ -21,11 +19,9 @@ index 1624c5db69bac..2b500dbefbc2d 100644
  config RTW88_DEBUG
  	bool "Realtek rtw88 debug support"
  	depends on RTW88_CORE
-diff --git a/drivers/net/wireless/realtek/rtw88/Makefile b/drivers/net/wireless/realtek/rtw88/Makefile
-index 9e095f8181483..3c1f08f12e44e 100644
 --- a/drivers/net/wireless/realtek/rtw88/Makefile
 +++ b/drivers/net/wireless/realtek/rtw88/Makefile
-@@ -44,6 +44,9 @@ rtw88_8821c-objs		:= rtw8821c.o rtw8821c_table.o
+@@ -43,6 +43,9 @@ rtw88_8821c-objs		:= rtw8821c.o rtw8821c
  obj-$(CPTCFG_RTW88_8821CE)	+= rtw88_8821ce.o
  rtw88_8821ce-objs		:= rtw8821ce.o
  
@@ -35,11 +31,9 @@ index 9e095f8181483..3c1f08f12e44e 100644
  obj-$(CPTCFG_RTW88_PCI)		+= rtw88_pci.o
  rtw88_pci-objs			:= pci.o
  
-diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821c.c b/drivers/net/wireless/realtek/rtw88/rtw8821c.c
-index 99eee128ae945..82e78559d8264 100644
 --- a/drivers/net/wireless/realtek/rtw88/rtw8821c.c
 +++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.c
-@@ -26,6 +26,12 @@ static void rtw8821ce_efuse_parsing(struct rtw_efuse *efuse,
+@@ -26,6 +26,12 @@ static void rtw8821ce_efuse_parsing(stru
  	ether_addr_copy(efuse->addr, map->e.mac_addr);
  }
  
@@ -52,7 +46,7 @@ index 99eee128ae945..82e78559d8264 100644
  enum rtw8821ce_rf_set {
  	SWITCH_TO_BTG,
  	SWITCH_TO_WLG,
-@@ -68,6 +74,9 @@ static int rtw8821c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+@@ -65,6 +71,9 @@ static int rtw8821c_read_efuse(struct rt
  	case RTW_HCI_TYPE_PCIE:
  		rtw8821ce_efuse_parsing(efuse, map);
  		break;
@@ -62,7 +56,7 @@ index 99eee128ae945..82e78559d8264 100644
  	default:
  		/* unsupported now */
  		return -ENOTSUPP;
-@@ -1142,6 +1151,18 @@ static void rtw8821c_phy_cck_pd_set(struct rtw_dev *rtwdev, u8 new_lvl)
+@@ -1128,6 +1137,18 @@ static void rtw8821c_phy_cck_pd_set(stru
  			 dm_info->cck_pd_default + new_lvl * 2);
  }
  
@@ -81,7 +75,7 @@ index 99eee128ae945..82e78559d8264 100644
  static struct rtw_pwr_seq_cmd trans_carddis_to_cardemu_8821c[] = {
  	{0x0086,
  	 RTW_PWR_CUT_ALL_MSK,
-@@ -1499,6 +1499,9 @@
+@@ -1499,6 +1520,9 @@ static const struct rtw_intf_phy_para_ta
  static const struct rtw_rfe_def rtw8821c_rfe_defs[] = {
  	[0] = RTW_DEF_RFE(8821c, 0, 0),
  	[2] = RTW_DEF_RFE_EXT(8821c, 0, 0, 2),
@@ -91,7 +85,7 @@ index 99eee128ae945..82e78559d8264 100644
  };
  
  static struct rtw_hw_reg rtw8821c_dig[] = {
-@@ -1589,6 +1611,7 @@ static struct rtw_chip_ops rtw8821c_ops = {
+@@ -1573,6 +1597,7 @@ static struct rtw_chip_ops rtw8821c_ops
  	.config_bfee		= rtw8821c_bf_config_bfee,
  	.set_gid_table		= rtw_bf_set_gid_table,
  	.cfg_csi_rate		= rtw_bf_cfg_csi_rate,
@@ -99,8 +93,6 @@ index 99eee128ae945..82e78559d8264 100644
  
  	.coex_set_init		= rtw8821c_coex_cfg_init,
  	.coex_set_ant_switch	= rtw8821c_coex_cfg_ant_switch,
-diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821c.h b/drivers/net/wireless/realtek/rtw88/rtw8821c.h
-index d9fbddd7b0f35..e2e17a822e48d 100644
 --- a/drivers/net/wireless/realtek/rtw88/rtw8821c.h
 +++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.h
 @@ -9,6 +9,26 @@
@@ -138,9 +130,6 @@ index d9fbddd7b0f35..e2e17a822e48d 100644
  	};
  };
  
-diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821cu.c b/drivers/net/wireless/realtek/rtw88/rtw8821cu.c
-new file mode 100644
-index 0000000000000..f43e200515f5b
 --- /dev/null
 +++ b/drivers/net/wireless/realtek/rtw88/rtw8821cu.c
 @@ -0,0 +1,50 @@
@@ -194,9 +183,6 @@ index 0000000000000..f43e200515f5b
 +MODULE_AUTHOR("Hans Ulli Kroll <linux@ulli-kroll.de>");
 +MODULE_DESCRIPTION("Realtek 802.11ac wireless 8821cu driver");
 +MODULE_LICENSE("Dual BSD/GPL");
-diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821cu.h b/drivers/net/wireless/realtek/rtw88/rtw8821cu.h
-new file mode 100644
-index 0000000000000..c896792240011
 --- /dev/null
 +++ b/drivers/net/wireless/realtek/rtw88/rtw8821cu.h
 @@ -0,0 +1,10 @@

--- a/package/kernel/mac80211/patches/rtl/010-rtw88-disable-powersave-modes-for-USB-devices.patch
+++ b/package/kernel/mac80211/patches/rtl/010-rtw88-disable-powersave-modes-for-USB-devices.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireless/realtek/rtw88/mac80211.c
-index 3c07485d6ba47..fb5faf3bf1eed 100644
 --- a/drivers/net/wireless/realtek/rtw88/mac80211.c
 +++ b/drivers/net/wireless/realtek/rtw88/mac80211.c
-@@ -89,7 +89,8 @@ static int rtw_ops_config(struct ieee80211_hw *hw, u32 changed)
+@@ -85,7 +85,8 @@ static int rtw_ops_config(struct ieee802
  	}
  
  	if (changed & IEEE80211_CONF_CHANGE_PS) {

--- a/package/kernel/mac80211/patches/subsys/346-mac80211-mesh-clean-up-rx_bcn_presp-API.patch
+++ b/package/kernel/mac80211/patches/subsys/346-mac80211-mesh-clean-up-rx_bcn_presp-API.patch
@@ -1,0 +1,110 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Mon, 20 Sep 2021 15:40:07 +0200
+Subject: [PATCH] mac80211: mesh: clean up rx_bcn_presp API
+
+commit a5b983c6073140b624f64e79fea6d33c3e4315a0 upstream.
+
+We currently pass the entire elements to the rx_bcn_presp()
+method, but only need mesh_config. Additionally, we use the
+length of the elements to calculate back the entire frame's
+length, but that's confusing - just pass the length of the
+frame instead.
+
+Link: https://lore.kernel.org/r/20210920154009.a18ed3d2da6c.I1824b773a0fbae4453e1433c184678ca14e8df45@changeid
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/ieee80211_i.h
++++ b/net/mac80211/ieee80211_i.h
+@@ -645,10 +645,9 @@ struct ieee80211_if_ocb {
+  */
+ struct ieee802_11_elems;
+ struct ieee80211_mesh_sync_ops {
+-	void (*rx_bcn_presp)(struct ieee80211_sub_if_data *sdata,
+-			     u16 stype,
+-			     struct ieee80211_mgmt *mgmt,
+-			     struct ieee802_11_elems *elems,
++	void (*rx_bcn_presp)(struct ieee80211_sub_if_data *sdata, u16 stype,
++			     struct ieee80211_mgmt *mgmt, unsigned int len,
++			     const struct ieee80211_meshconf_ie *mesh_cfg,
+ 			     struct ieee80211_rx_status *rx_status);
+ 
+ 	/* should be called with beacon_data under RCU read lock */
+--- a/net/mac80211/mesh.c
++++ b/net/mac80211/mesh.c
+@@ -1354,8 +1354,8 @@ static void ieee80211_mesh_rx_bcn_presp(
+ 	}
+ 
+ 	if (ifmsh->sync_ops)
+-		ifmsh->sync_ops->rx_bcn_presp(sdata,
+-			stype, mgmt, &elems, rx_status);
++		ifmsh->sync_ops->rx_bcn_presp(sdata, stype, mgmt, len,
++					      elems.mesh_config, rx_status);
+ }
+ 
+ int ieee80211_mesh_finish_csa(struct ieee80211_sub_if_data *sdata)
+--- a/net/mac80211/mesh_sync.c
++++ b/net/mac80211/mesh_sync.c
+@@ -3,6 +3,7 @@
+  * Copyright 2011-2012, Pavel Zubarev <pavel.zubarev@gmail.com>
+  * Copyright 2011-2012, Marco Porsch <marco.porsch@s2005.tu-chemnitz.de>
+  * Copyright 2011-2012, cozybit Inc.
++ * Copyright (C) 2021 Intel Corporation
+  */
+ 
+ #include "ieee80211_i.h"
+@@ -35,12 +36,12 @@ struct sync_method {
+ /**
+  * mesh_peer_tbtt_adjusting - check if an mp is currently adjusting its TBTT
+  *
+- * @ie: information elements of a management frame from the mesh peer
++ * @cfg: mesh config element from the mesh peer (or %NULL)
+  */
+-static bool mesh_peer_tbtt_adjusting(struct ieee802_11_elems *ie)
++static bool mesh_peer_tbtt_adjusting(const struct ieee80211_meshconf_ie *cfg)
+ {
+-	return (ie->mesh_config->meshconf_cap &
+-			IEEE80211_MESHCONF_CAPAB_TBTT_ADJUSTING) != 0;
++	return cfg &&
++	       (cfg->meshconf_cap & IEEE80211_MESHCONF_CAPAB_TBTT_ADJUSTING);
+ }
+ 
+ void mesh_sync_adjust_tsf(struct ieee80211_sub_if_data *sdata)
+@@ -76,11 +77,11 @@ void mesh_sync_adjust_tsf(struct ieee802
+ 	}
+ }
+ 
+-static void mesh_sync_offset_rx_bcn_presp(struct ieee80211_sub_if_data *sdata,
+-				   u16 stype,
+-				   struct ieee80211_mgmt *mgmt,
+-				   struct ieee802_11_elems *elems,
+-				   struct ieee80211_rx_status *rx_status)
++static void
++mesh_sync_offset_rx_bcn_presp(struct ieee80211_sub_if_data *sdata, u16 stype,
++			      struct ieee80211_mgmt *mgmt, unsigned int len,
++			      const struct ieee80211_meshconf_ie *mesh_cfg,
++			      struct ieee80211_rx_status *rx_status)
+ {
+ 	struct ieee80211_if_mesh *ifmsh = &sdata->u.mesh;
+ 	struct ieee80211_local *local = sdata->local;
+@@ -101,10 +102,7 @@ static void mesh_sync_offset_rx_bcn_pres
+ 	 */
+ 	if (ieee80211_have_rx_timestamp(rx_status))
+ 		t_r = ieee80211_calculate_rx_timestamp(local, rx_status,
+-						       24 + 12 +
+-						       elems->total_len +
+-						       FCS_LEN,
+-						       24);
++						       len + FCS_LEN, 24);
+ 	else
+ 		t_r = drv_get_tsf(local, sdata);
+ 
+@@ -119,7 +117,7 @@ static void mesh_sync_offset_rx_bcn_pres
+ 	 * dot11MeshNbrOffsetMaxNeighbor non-peer non-MBSS neighbors
+ 	 */
+ 
+-	if (elems->mesh_config && mesh_peer_tbtt_adjusting(elems)) {
++	if (mesh_peer_tbtt_adjusting(mesh_cfg)) {
+ 		msync_dbg(sdata, "STA %pM : is adjusting TBTT\n",
+ 			  sta->sta.addr);
+ 		goto no_sync;

--- a/package/kernel/mac80211/patches/subsys/347-mac80211-move-CRC-into-struct-ieee802_11_elems.patch
+++ b/package/kernel/mac80211/patches/subsys/347-mac80211-move-CRC-into-struct-ieee802_11_elems.patch
@@ -1,0 +1,82 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Mon, 20 Sep 2021 15:40:08 +0200
+Subject: [PATCH] mac80211: move CRC into struct ieee802_11_elems
+
+commit c6e37ed498f958254b5459253199e816b6bfc52f upstream.
+
+We're currently returning this value, but to prepare for
+returning the allocated structure, move it into there.
+
+Link: https://lore.kernel.org/r/20210920154009.479b8ebf999d.If0d4ba75ee38998dc3eeae25058aa748efcb2fc9@changeid
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/ieee80211_i.h
++++ b/net/mac80211/ieee80211_i.h
+@@ -1525,6 +1525,7 @@ struct ieee80211_csa_ie {
+ struct ieee802_11_elems {
+ 	const u8 *ie_start;
+ 	size_t total_len;
++	u32 crc;
+ 
+ 	/* pointers to IEs */
+ 	const struct ieee80211_tdls_lnkie *lnk_id;
+@@ -2084,10 +2085,10 @@ static inline void ieee80211_tx_skb(stru
+ 	ieee80211_tx_skb_tid(sdata, skb, 7);
+ }
+ 
+-u32 ieee802_11_parse_elems_crc(const u8 *start, size_t len, bool action,
+-			       struct ieee802_11_elems *elems,
+-			       u64 filter, u32 crc, u8 *transmitter_bssid,
+-			       u8 *bss_bssid);
++void ieee802_11_parse_elems_crc(const u8 *start, size_t len, bool action,
++				struct ieee802_11_elems *elems,
++				u64 filter, u32 crc, u8 *transmitter_bssid,
++				u8 *bss_bssid);
+ static inline void ieee802_11_parse_elems(const u8 *start, size_t len,
+ 					  bool action,
+ 					  struct ieee802_11_elems *elems,
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -4096,10 +4096,11 @@ static void ieee80211_rx_mgmt_beacon(str
+ 	 */
+ 	if (!ieee80211_is_s1g_beacon(hdr->frame_control))
+ 		ncrc = crc32_be(0, (void *)&mgmt->u.beacon.beacon_int, 4);
+-	ncrc = ieee802_11_parse_elems_crc(variable,
+-					  len - baselen, false, &elems,
+-					  care_about_ies, ncrc,
+-					  mgmt->bssid, bssid);
++	ieee802_11_parse_elems_crc(variable,
++				   len - baselen, false, &elems,
++				   care_about_ies, ncrc,
++				   mgmt->bssid, bssid);
++	ncrc = elems.crc;
+ 
+ 	if (ieee80211_hw_check(&local->hw, PS_NULLFUNC_STACK) &&
+ 	    ieee80211_check_tim(elems.tim, elems.tim_len, bss_conf->aid)) {
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1469,10 +1469,10 @@ static size_t ieee802_11_find_bssid_prof
+ 	return found ? profile_len : 0;
+ }
+ 
+-u32 ieee802_11_parse_elems_crc(const u8 *start, size_t len, bool action,
+-			       struct ieee802_11_elems *elems,
+-			       u64 filter, u32 crc, u8 *transmitter_bssid,
+-			       u8 *bss_bssid)
++void ieee802_11_parse_elems_crc(const u8 *start, size_t len, bool action,
++				struct ieee802_11_elems *elems,
++				u64 filter, u32 crc, u8 *transmitter_bssid,
++				u8 *bss_bssid)
+ {
+ 	const struct element *non_inherit = NULL;
+ 	u8 *nontransmitted_profile;
+@@ -1524,7 +1524,7 @@ u32 ieee802_11_parse_elems_crc(const u8
+ 
+ 	kfree(nontransmitted_profile);
+ 
+-	return crc;
++	elems->crc = crc;
+ }
+ 
+ void ieee80211_regulatory_limit_wmm_params(struct ieee80211_sub_if_data *sdata,

--- a/package/kernel/mac80211/patches/subsys/348-mac80211-mlme-find-auth-challenge-directly.patch
+++ b/package/kernel/mac80211/patches/subsys/348-mac80211-mlme-find-auth-challenge-directly.patch
@@ -1,0 +1,80 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Mon, 20 Sep 2021 15:40:09 +0200
+Subject: [PATCH] mac80211: mlme: find auth challenge directly
+
+commit 49a765d6785e99157ff5091cc37485732496864e upstream.
+
+There's no need to parse all elements etc. just to find the
+authentication challenge - use cfg80211_find_elem() instead.
+This also allows us to remove WLAN_EID_CHALLENGE handling
+from the element parsing entirely.
+
+Link: https://lore.kernel.org/r/20210920154009.45f9b3a15722.Ice3159ffad03a007d6154cbf1fb3a8c48489e86f@changeid
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/ieee80211_i.h
++++ b/net/mac80211/ieee80211_i.h
+@@ -1535,7 +1535,6 @@ struct ieee802_11_elems {
+ 	const u8 *supp_rates;
+ 	const u8 *ds_params;
+ 	const struct ieee80211_tim_ie *tim;
+-	const u8 *challenge;
+ 	const u8 *rsn;
+ 	const u8 *rsnx;
+ 	const u8 *erp_info;
+@@ -1589,7 +1588,6 @@ struct ieee802_11_elems {
+ 	u8 ssid_len;
+ 	u8 supp_rates_len;
+ 	u8 tim_len;
+-	u8 challenge_len;
+ 	u8 rsn_len;
+ 	u8 rsnx_len;
+ 	u8 ext_supp_rates_len;
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -2889,17 +2889,17 @@ static void ieee80211_auth_challenge(str
+ {
+ 	struct ieee80211_local *local = sdata->local;
+ 	struct ieee80211_mgd_auth_data *auth_data = sdata->u.mgd.auth_data;
++	const struct element *challenge;
+ 	u8 *pos;
+-	struct ieee802_11_elems elems;
+ 	u32 tx_flags = 0;
+ 	struct ieee80211_prep_tx_info info = {
+ 		.subtype = IEEE80211_STYPE_AUTH,
+ 	};
+ 
+ 	pos = mgmt->u.auth.variable;
+-	ieee802_11_parse_elems(pos, len - (pos - (u8 *)mgmt), false, &elems,
+-			       mgmt->bssid, auth_data->bss->bssid);
+-	if (!elems.challenge)
++	challenge = cfg80211_find_elem(WLAN_EID_CHALLENGE, pos,
++				       len - (pos - (u8 *)mgmt));
++	if (!challenge)
+ 		return;
+ 	auth_data->expected_transaction = 4;
+ 	drv_mgd_prepare_tx(sdata->local, sdata, &info);
+@@ -2907,7 +2907,8 @@ static void ieee80211_auth_challenge(str
+ 		tx_flags = IEEE80211_TX_CTL_REQ_TX_STATUS |
+ 			   IEEE80211_TX_INTFL_MLME_CONN_TX;
+ 	ieee80211_send_auth(sdata, 3, auth_data->algorithm, 0,
+-			    elems.challenge - 2, elems.challenge_len + 2,
++			    (void *)challenge,
++			    challenge->datalen + sizeof(*challenge),
+ 			    auth_data->bss->bssid, auth_data->bss->bssid,
+ 			    auth_data->key, auth_data->key_len,
+ 			    auth_data->key_idx, tx_flags);
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1120,10 +1120,6 @@ _ieee802_11_parse_elems_crc(const u8 *st
+ 			} else
+ 				elem_parse_failed = true;
+ 			break;
+-		case WLAN_EID_CHALLENGE:
+-			elems->challenge = pos;
+-			elems->challenge_len = elen;
+-			break;
+ 		case WLAN_EID_VENDOR_SPECIFIC:
+ 			if (elen >= 4 && pos[0] == 0x00 && pos[1] == 0x50 &&
+ 			    pos[2] == 0xf2) {

--- a/package/kernel/mac80211/patches/subsys/349-mac80211-always-allocate-struct-ieee802_11_elems.patch
+++ b/package/kernel/mac80211/patches/subsys/349-mac80211-always-allocate-struct-ieee802_11_elems.patch
@@ -1,0 +1,1143 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Mon, 20 Sep 2021 15:40:10 +0200
+Subject: [PATCH] mac80211: always allocate struct ieee802_11_elems
+
+As the 802.11 spec evolves, we need to parse more and more
+elements. This is causing the struct to grow, and we can no
+longer get away with putting it on the stack.
+
+Change the API to always dynamically allocate and return an
+allocated pointer that must be kfree()d later.
+
+As an alternative, I contemplated a scheme whereby we'd say
+in the code which elements we needed, e.g.
+
+    DECLARE_ELEMENT_PARSER(elems,
+                           SUPPORTED_CHANNELS,
+                           CHANNEL_SWITCH,
+                           EXT(KEY_DELIVERY));
+
+    ieee802_11_parse_elems(..., &elems, ...);
+
+and while I think this is possible and will save us a lot
+since most individual places only care about a small subset
+of the elements, it ended up being a bit more work since a
+lot of places do the parsing and then pass the struct to
+other functions, sometimes with multiple levels.
+
+Link: https://lore.kernel.org/r/20210920154009.26caff6b5998.I05ae58768e990e611aee8eca8abefd9d7bc15e05@changeid
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/agg-rx.c
++++ b/net/mac80211/agg-rx.c
+@@ -478,7 +478,7 @@ void ieee80211_process_addba_request(str
+ 				     size_t len)
+ {
+ 	u16 capab, tid, timeout, ba_policy, buf_size, start_seq_num;
+-	struct ieee802_11_elems elems = { };
++	struct ieee802_11_elems *elems = NULL;
+ 	u8 dialog_token;
+ 	int ies_len;
+ 
+@@ -496,16 +496,17 @@ void ieee80211_process_addba_request(str
+ 	ies_len = len - offsetof(struct ieee80211_mgmt,
+ 				 u.action.u.addba_req.variable);
+ 	if (ies_len) {
+-		ieee802_11_parse_elems(mgmt->u.action.u.addba_req.variable,
+-                                ies_len, true, &elems, mgmt->bssid, NULL);
+-		if (elems.parse_error)
++		elems = ieee802_11_parse_elems(mgmt->u.action.u.addba_req.variable,
++					       ies_len, true, mgmt->bssid, NULL);
++		if (!elems || elems->parse_error)
+ 			return;
+ 	}
+ 
+ 	__ieee80211_start_rx_ba_session(sta, dialog_token, timeout,
+ 					start_seq_num, ba_policy, tid,
+ 					buf_size, true, false,
+-					elems.addba_ext_ie);
++					elems ? elems->addba_ext_ie : NULL);
++	kfree(elems);
+ }
+ 
+ void ieee80211_manage_rx_ba_offl(struct ieee80211_vif *vif,
+--- a/net/mac80211/ibss.c
++++ b/net/mac80211/ibss.c
+@@ -9,7 +9,7 @@
+  * Copyright 2009, Johannes Berg <johannes@sipsolutions.net>
+  * Copyright 2013-2014  Intel Mobile Communications GmbH
+  * Copyright(c) 2016 Intel Deutschland GmbH
+- * Copyright(c) 2018-2020 Intel Corporation
++ * Copyright(c) 2018-2021 Intel Corporation
+  */
+ 
+ #include <linux/delay.h>
+@@ -1589,7 +1589,7 @@ void ieee80211_rx_mgmt_probe_beacon(stru
+ 				    struct ieee80211_rx_status *rx_status)
+ {
+ 	size_t baselen;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 
+ 	BUILD_BUG_ON(offsetof(typeof(mgmt->u.probe_resp), variable) !=
+ 		     offsetof(typeof(mgmt->u.beacon), variable));
+@@ -1602,10 +1602,14 @@ void ieee80211_rx_mgmt_probe_beacon(stru
+ 	if (baselen > len)
+ 		return;
+ 
+-	ieee802_11_parse_elems(mgmt->u.probe_resp.variable, len - baselen,
+-			       false, &elems, mgmt->bssid, NULL);
+-
+-	ieee80211_rx_bss_info(sdata, mgmt, len, rx_status, &elems);
++	elems = ieee802_11_parse_elems(mgmt->u.probe_resp.variable,
++				       len - baselen, false,
++				       mgmt->bssid, NULL);
++
++	if (elems) {
++		ieee80211_rx_bss_info(sdata, mgmt, len, rx_status, elems);
++		kfree(elems);
++	}
+ }
+ 
+ void ieee80211_ibss_rx_queued_mgmt(struct ieee80211_sub_if_data *sdata,
+@@ -1614,7 +1618,7 @@ void ieee80211_ibss_rx_queued_mgmt(struc
+ 	struct ieee80211_rx_status *rx_status;
+ 	struct ieee80211_mgmt *mgmt;
+ 	u16 fc;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	int ies_len;
+ 
+ 	rx_status = IEEE80211_SKB_RXCB(skb);
+@@ -1651,15 +1655,16 @@ void ieee80211_ibss_rx_queued_mgmt(struc
+ 			if (ies_len < 0)
+ 				break;
+ 
+-			ieee802_11_parse_elems(
++			elems = ieee802_11_parse_elems(
+ 				mgmt->u.action.u.chan_switch.variable,
+-				ies_len, true, &elems, mgmt->bssid, NULL);
++				ies_len, true, mgmt->bssid, NULL);
+ 
+-			if (elems.parse_error)
++			if (!elems || elems->parse_error)
+ 				break;
+ 
+ 			ieee80211_rx_mgmt_spectrum_mgmt(sdata, mgmt, skb->len,
+-							rx_status, &elems);
++							rx_status, elems);
++			kfree(elems);
+ 			break;
+ 		}
+ 	}
+--- a/net/mac80211/ieee80211_i.h
++++ b/net/mac80211/ieee80211_i.h
+@@ -2083,18 +2083,18 @@ static inline void ieee80211_tx_skb(stru
+ 	ieee80211_tx_skb_tid(sdata, skb, 7);
+ }
+ 
+-void ieee802_11_parse_elems_crc(const u8 *start, size_t len, bool action,
+-				struct ieee802_11_elems *elems,
+-				u64 filter, u32 crc, u8 *transmitter_bssid,
+-				u8 *bss_bssid);
+-static inline void ieee802_11_parse_elems(const u8 *start, size_t len,
+-					  bool action,
+-					  struct ieee802_11_elems *elems,
+-					  u8 *transmitter_bssid,
+-					  u8 *bss_bssid)
++struct ieee802_11_elems *ieee802_11_parse_elems_crc(const u8 *start, size_t len,
++						    bool action,
++						    u64 filter, u32 crc,
++						    const u8 *transmitter_bssid,
++						    const u8 *bss_bssid);
++static inline struct ieee802_11_elems *
++ieee802_11_parse_elems(const u8 *start, size_t len, bool action,
++		       const u8 *transmitter_bssid,
++		       const u8 *bss_bssid)
+ {
+-	ieee802_11_parse_elems_crc(start, len, action, elems, 0, 0,
+-				   transmitter_bssid, bss_bssid);
++	return ieee802_11_parse_elems_crc(start, len, action, 0, 0,
++					  transmitter_bssid, bss_bssid);
+ }
+ 
+ 
+--- a/net/mac80211/mesh.c
++++ b/net/mac80211/mesh.c
+@@ -1247,7 +1247,7 @@ ieee80211_mesh_rx_probe_req(struct ieee8
+ 	struct sk_buff *presp;
+ 	struct beacon_data *bcn;
+ 	struct ieee80211_mgmt *hdr;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	size_t baselen;
+ 	u8 *pos;
+ 
+@@ -1256,22 +1256,24 @@ ieee80211_mesh_rx_probe_req(struct ieee8
+ 	if (baselen > len)
+ 		return;
+ 
+-	ieee802_11_parse_elems(pos, len - baselen, false, &elems, mgmt->bssid,
+-			       NULL);
+-
+-	if (!elems.mesh_id)
++	elems = ieee802_11_parse_elems(pos, len - baselen, false, mgmt->bssid,
++				       NULL);
++	if (!elems)
+ 		return;
+ 
++	if (!elems->mesh_id)
++		goto free;
++
+ 	/* 802.11-2012 10.1.4.3.2 */
+ 	if ((!ether_addr_equal(mgmt->da, sdata->vif.addr) &&
+ 	     !is_broadcast_ether_addr(mgmt->da)) ||
+-	    elems.ssid_len != 0)
+-		return;
++	    elems->ssid_len != 0)
++		goto free;
+ 
+-	if (elems.mesh_id_len != 0 &&
+-	    (elems.mesh_id_len != ifmsh->mesh_id_len ||
+-	     memcmp(elems.mesh_id, ifmsh->mesh_id, ifmsh->mesh_id_len)))
+-		return;
++	if (elems->mesh_id_len != 0 &&
++	    (elems->mesh_id_len != ifmsh->mesh_id_len ||
++	     memcmp(elems->mesh_id, ifmsh->mesh_id, ifmsh->mesh_id_len)))
++		goto free;
+ 
+ 	rcu_read_lock();
+ 	bcn = rcu_dereference(ifmsh->beacon);
+@@ -1295,6 +1297,8 @@ ieee80211_mesh_rx_probe_req(struct ieee8
+ 	ieee80211_tx_skb(sdata, presp);
+ out:
+ 	rcu_read_unlock();
++free:
++	kfree(elems);
+ }
+ 
+ static void ieee80211_mesh_rx_bcn_presp(struct ieee80211_sub_if_data *sdata,
+@@ -1305,7 +1309,7 @@ static void ieee80211_mesh_rx_bcn_presp(
+ {
+ 	struct ieee80211_local *local = sdata->local;
+ 	struct ieee80211_if_mesh *ifmsh = &sdata->u.mesh;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	struct ieee80211_channel *channel;
+ 	size_t baselen;
+ 	int freq;
+@@ -1320,42 +1324,47 @@ static void ieee80211_mesh_rx_bcn_presp(
+ 	if (baselen > len)
+ 		return;
+ 
+-	ieee802_11_parse_elems(mgmt->u.probe_resp.variable, len - baselen,
+-			       false, &elems, mgmt->bssid, NULL);
++	elems = ieee802_11_parse_elems(mgmt->u.probe_resp.variable,
++				       len - baselen,
++				       false, mgmt->bssid, NULL);
++	if (!elems)
++		return;
+ 
+ 	/* ignore non-mesh or secure / unsecure mismatch */
+-	if ((!elems.mesh_id || !elems.mesh_config) ||
+-	    (elems.rsn && sdata->u.mesh.security == IEEE80211_MESH_SEC_NONE) ||
+-	    (!elems.rsn && sdata->u.mesh.security != IEEE80211_MESH_SEC_NONE))
+-		return;
++	if ((!elems->mesh_id || !elems->mesh_config) ||
++	    (elems->rsn && sdata->u.mesh.security == IEEE80211_MESH_SEC_NONE) ||
++	    (!elems->rsn && sdata->u.mesh.security != IEEE80211_MESH_SEC_NONE))
++		goto free;
+ 
+-	if (elems.ds_params)
+-		freq = ieee80211_channel_to_frequency(elems.ds_params[0], band);
++	if (elems->ds_params)
++		freq = ieee80211_channel_to_frequency(elems->ds_params[0], band);
+ 	else
+ 		freq = rx_status->freq;
+ 
+ 	channel = ieee80211_get_channel(local->hw.wiphy, freq);
+ 
+ 	if (!channel || channel->flags & IEEE80211_CHAN_DISABLED)
+-		return;
++		goto free;
+ 
+-	if (mesh_matches_local(sdata, &elems)) {
++	if (mesh_matches_local(sdata, elems)) {
+ 		mpl_dbg(sdata, "rssi_threshold=%d,rx_status->signal=%d\n",
+ 			sdata->u.mesh.mshcfg.rssi_threshold, rx_status->signal);
+ 		if (!sdata->u.mesh.user_mpm ||
+ 		    sdata->u.mesh.mshcfg.rssi_threshold == 0 ||
+ 		    sdata->u.mesh.mshcfg.rssi_threshold < rx_status->signal)
+-			mesh_neighbour_update(sdata, mgmt->sa, &elems,
++			mesh_neighbour_update(sdata, mgmt->sa, elems,
+ 					      rx_status);
+ 
+ 		if (ifmsh->csa_role != IEEE80211_MESH_CSA_ROLE_INIT &&
+ 		    !sdata->vif.csa_active)
+-			ieee80211_mesh_process_chnswitch(sdata, &elems, true);
++			ieee80211_mesh_process_chnswitch(sdata, elems, true);
+ 	}
+ 
+ 	if (ifmsh->sync_ops)
+ 		ifmsh->sync_ops->rx_bcn_presp(sdata, stype, mgmt, len,
+-					      elems.mesh_config, rx_status);
++					      elems->mesh_config, rx_status);
++free:
++	kfree(elems);
+ }
+ 
+ int ieee80211_mesh_finish_csa(struct ieee80211_sub_if_data *sdata)
+@@ -1447,7 +1456,7 @@ static void mesh_rx_csa_frame(struct iee
+ 			      struct ieee80211_mgmt *mgmt, size_t len)
+ {
+ 	struct ieee80211_if_mesh *ifmsh = &sdata->u.mesh;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	u16 pre_value;
+ 	bool fwd_csa = true;
+ 	size_t baselen;
+@@ -1460,33 +1469,37 @@ static void mesh_rx_csa_frame(struct iee
+ 	pos = mgmt->u.action.u.chan_switch.variable;
+ 	baselen = offsetof(struct ieee80211_mgmt,
+ 			   u.action.u.chan_switch.variable);
+-	ieee802_11_parse_elems(pos, len - baselen, true, &elems,
+-			       mgmt->bssid, NULL);
+-
+-	if (!mesh_matches_local(sdata, &elems))
++	elems = ieee802_11_parse_elems(pos, len - baselen, true,
++				       mgmt->bssid, NULL);
++	if (!elems)
+ 		return;
+ 
+-	ifmsh->chsw_ttl = elems.mesh_chansw_params_ie->mesh_ttl;
++	if (!mesh_matches_local(sdata, elems))
++		goto free;
++
++	ifmsh->chsw_ttl = elems->mesh_chansw_params_ie->mesh_ttl;
+ 	if (!--ifmsh->chsw_ttl)
+ 		fwd_csa = false;
+ 
+-	pre_value = le16_to_cpu(elems.mesh_chansw_params_ie->mesh_pre_value);
++	pre_value = le16_to_cpu(elems->mesh_chansw_params_ie->mesh_pre_value);
+ 	if (ifmsh->pre_value >= pre_value)
+-		return;
++		goto free;
+ 
+ 	ifmsh->pre_value = pre_value;
+ 
+ 	if (!sdata->vif.csa_active &&
+-	    !ieee80211_mesh_process_chnswitch(sdata, &elems, false)) {
++	    !ieee80211_mesh_process_chnswitch(sdata, elems, false)) {
+ 		mcsa_dbg(sdata, "Failed to process CSA action frame");
+-		return;
++		goto free;
+ 	}
+ 
+ 	/* forward or re-broadcast the CSA frame */
+ 	if (fwd_csa) {
+-		if (mesh_fwd_csa_frame(sdata, mgmt, len, &elems) < 0)
++		if (mesh_fwd_csa_frame(sdata, mgmt, len, elems) < 0)
+ 			mcsa_dbg(sdata, "Failed to forward the CSA frame");
+ 	}
++free:
++	kfree(elems);
+ }
+ 
+ static void ieee80211_mesh_rx_mgmt_action(struct ieee80211_sub_if_data *sdata,
+--- a/net/mac80211/mesh_hwmp.c
++++ b/net/mac80211/mesh_hwmp.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ /*
+  * Copyright (c) 2008, 2009 open80211s Ltd.
+- * Copyright (C) 2019 Intel Corporation
++ * Copyright (C) 2019, 2021 Intel Corporation
+  * Author:     Luis Carlos Cobo <luisca@cozybit.com>
+  */
+ 
+@@ -908,7 +908,7 @@ static void hwmp_rann_frame_process(stru
+ void mesh_rx_path_sel_frame(struct ieee80211_sub_if_data *sdata,
+ 			    struct ieee80211_mgmt *mgmt, size_t len)
+ {
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	size_t baselen;
+ 	u32 path_metric;
+ 	struct sta_info *sta;
+@@ -926,37 +926,41 @@ void mesh_rx_path_sel_frame(struct ieee8
+ 	rcu_read_unlock();
+ 
+ 	baselen = (u8 *) mgmt->u.action.u.mesh_action.variable - (u8 *) mgmt;
+-	ieee802_11_parse_elems(mgmt->u.action.u.mesh_action.variable,
+-			       len - baselen, false, &elems, mgmt->bssid, NULL);
++	elems = ieee802_11_parse_elems(mgmt->u.action.u.mesh_action.variable,
++				       len - baselen, false, mgmt->bssid, NULL);
++	if (!elems)
++		return;
+ 
+-	if (elems.preq) {
+-		if (elems.preq_len != 37)
++	if (elems->preq) {
++		if (elems->preq_len != 37)
+ 			/* Right now we support just 1 destination and no AE */
+-			return;
+-		path_metric = hwmp_route_info_get(sdata, mgmt, elems.preq,
++			goto free;
++		path_metric = hwmp_route_info_get(sdata, mgmt, elems->preq,
+ 						  MPATH_PREQ);
+ 		if (path_metric)
+-			hwmp_preq_frame_process(sdata, mgmt, elems.preq,
++			hwmp_preq_frame_process(sdata, mgmt, elems->preq,
+ 						path_metric);
+ 	}
+-	if (elems.prep) {
+-		if (elems.prep_len != 31)
++	if (elems->prep) {
++		if (elems->prep_len != 31)
+ 			/* Right now we support no AE */
+-			return;
+-		path_metric = hwmp_route_info_get(sdata, mgmt, elems.prep,
++			goto free;
++		path_metric = hwmp_route_info_get(sdata, mgmt, elems->prep,
+ 						  MPATH_PREP);
+ 		if (path_metric)
+-			hwmp_prep_frame_process(sdata, mgmt, elems.prep,
++			hwmp_prep_frame_process(sdata, mgmt, elems->prep,
+ 						path_metric);
+ 	}
+-	if (elems.perr) {
+-		if (elems.perr_len != 15)
++	if (elems->perr) {
++		if (elems->perr_len != 15)
+ 			/* Right now we support only one destination per PERR */
+-			return;
+-		hwmp_perr_frame_process(sdata, mgmt, elems.perr);
++			goto free;
++		hwmp_perr_frame_process(sdata, mgmt, elems->perr);
+ 	}
+-	if (elems.rann)
+-		hwmp_rann_frame_process(sdata, mgmt, elems.rann);
++	if (elems->rann)
++		hwmp_rann_frame_process(sdata, mgmt, elems->rann);
++free:
++	kfree(elems);
+ }
+ 
+ /**
+--- a/net/mac80211/mesh_plink.c
++++ b/net/mac80211/mesh_plink.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ /*
+  * Copyright (c) 2008, 2009 open80211s Ltd.
+- * Copyright (C) 2019 Intel Corporation
++ * Copyright (C) 2019, 2021 Intel Corporation
+  * Author:     Luis Carlos Cobo <luisca@cozybit.com>
+  */
+ #include <linux/gfp.h>
+@@ -1200,7 +1200,7 @@ void mesh_rx_plink_frame(struct ieee8021
+ 			 struct ieee80211_mgmt *mgmt, size_t len,
+ 			 struct ieee80211_rx_status *rx_status)
+ {
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	size_t baselen;
+ 	u8 *baseaddr;
+ 
+@@ -1228,7 +1228,8 @@ void mesh_rx_plink_frame(struct ieee8021
+ 		if (baselen > len)
+ 			return;
+ 	}
+-	ieee802_11_parse_elems(baseaddr, len - baselen, true, &elems,
+-			       mgmt->bssid, NULL);
+-	mesh_process_plink_frame(sdata, mgmt, &elems, rx_status);
++	elems = ieee802_11_parse_elems(baseaddr, len - baselen, true,
++				       mgmt->bssid, NULL);
++	mesh_process_plink_frame(sdata, mgmt, elems, rx_status);
++	kfree(elems);
+ }
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -3317,8 +3317,11 @@ static bool ieee80211_assoc_success(stru
+ 		aid = 0; /* TODO */
+ 	}
+ 	capab_info = le16_to_cpu(mgmt->u.assoc_resp.capab_info);
+-	ieee802_11_parse_elems(pos, len - (pos - (u8 *)mgmt), false, elems,
+-			       mgmt->bssid, assoc_data->bss->bssid);
++	elems = ieee802_11_parse_elems(pos, len - (pos - (u8 *)mgmt), false,
++				       mgmt->bssid, assoc_data->bss->bssid);
++
++	if (!elems)
++		return false;
+ 
+ 	if (elems->aid_resp)
+ 		aid = le16_to_cpu(elems->aid_resp->aid);
+@@ -3340,7 +3343,8 @@ static bool ieee80211_assoc_success(stru
+ 
+ 	if (!is_s1g && !elems->supp_rates) {
+ 		sdata_info(sdata, "no SuppRates element in AssocResp\n");
+-		return false;
++		ret = false;
++		goto out;
+ 	}
+ 
+ 	sdata->vif.bss_conf.aid = aid;
+@@ -3362,7 +3366,7 @@ static bool ieee80211_assoc_success(stru
+ 	     (!(ifmgd->flags & IEEE80211_STA_DISABLE_VHT) &&
+ 	      (!elems->vht_cap_elem || !elems->vht_operation)))) {
+ 		const struct cfg80211_bss_ies *ies;
+-		struct ieee802_11_elems bss_elems;
++		struct ieee802_11_elems *bss_elems;
+ 
+ 		rcu_read_lock();
+ 		ies = rcu_dereference(cbss->ies);
+@@ -3373,13 +3377,17 @@ static bool ieee80211_assoc_success(stru
+ 		if (!bss_ies)
+ 			return false;
+ 
+-		ieee802_11_parse_elems(bss_ies->data, bss_ies->len,
+-				       false, &bss_elems,
+-				       mgmt->bssid,
+-				       assoc_data->bss->bssid);
++		bss_elems = ieee802_11_parse_elems(bss_ies->data, bss_ies->len,
++						   false, mgmt->bssid,
++						   assoc_data->bss->bssid);
++		if (!bss_elems) {
++			ret = false;
++			goto out;
++		}
++
+ 		if (assoc_data->wmm &&
+-		    !elems->wmm_param && bss_elems.wmm_param) {
+-			elems->wmm_param = bss_elems.wmm_param;
++		    !elems->wmm_param && bss_elems->wmm_param) {
++			elems->wmm_param = bss_elems->wmm_param;
+ 			sdata_info(sdata,
+ 				   "AP bug: WMM param missing from AssocResp\n");
+ 		}
+@@ -3388,30 +3396,32 @@ static bool ieee80211_assoc_success(stru
+ 		 * Also check if we requested HT/VHT, otherwise the AP doesn't
+ 		 * have to include the IEs in the (re)association response.
+ 		 */
+-		if (!elems->ht_cap_elem && bss_elems.ht_cap_elem &&
++		if (!elems->ht_cap_elem && bss_elems->ht_cap_elem &&
+ 		    !(ifmgd->flags & IEEE80211_STA_DISABLE_HT)) {
+-			elems->ht_cap_elem = bss_elems.ht_cap_elem;
++			elems->ht_cap_elem = bss_elems->ht_cap_elem;
+ 			sdata_info(sdata,
+ 				   "AP bug: HT capability missing from AssocResp\n");
+ 		}
+-		if (!elems->ht_operation && bss_elems.ht_operation &&
++		if (!elems->ht_operation && bss_elems->ht_operation &&
+ 		    !(ifmgd->flags & IEEE80211_STA_DISABLE_HT)) {
+-			elems->ht_operation = bss_elems.ht_operation;
++			elems->ht_operation = bss_elems->ht_operation;
+ 			sdata_info(sdata,
+ 				   "AP bug: HT operation missing from AssocResp\n");
+ 		}
+-		if (!elems->vht_cap_elem && bss_elems.vht_cap_elem &&
++		if (!elems->vht_cap_elem && bss_elems->vht_cap_elem &&
+ 		    !(ifmgd->flags & IEEE80211_STA_DISABLE_VHT)) {
+-			elems->vht_cap_elem = bss_elems.vht_cap_elem;
++			elems->vht_cap_elem = bss_elems->vht_cap_elem;
+ 			sdata_info(sdata,
+ 				   "AP bug: VHT capa missing from AssocResp\n");
+ 		}
+-		if (!elems->vht_operation && bss_elems.vht_operation &&
++		if (!elems->vht_operation && bss_elems->vht_operation &&
+ 		    !(ifmgd->flags & IEEE80211_STA_DISABLE_VHT)) {
+-			elems->vht_operation = bss_elems.vht_operation;
++			elems->vht_operation = bss_elems->vht_operation;
+ 			sdata_info(sdata,
+ 				   "AP bug: VHT operation missing from AssocResp\n");
+ 		}
++
++		kfree(bss_elems);
+ 	}
+ 
+ 	/*
+@@ -3656,6 +3666,7 @@ static bool ieee80211_assoc_success(stru
+ 
+ 	ret = true;
+  out:
++	kfree(elems);
+ 	kfree(bss_ies);
+ 	return ret;
+ }
+@@ -3667,7 +3678,7 @@ static void ieee80211_rx_mgmt_assoc_resp
+ 	struct ieee80211_if_managed *ifmgd = &sdata->u.mgd;
+ 	struct ieee80211_mgd_assoc_data *assoc_data = ifmgd->assoc_data;
+ 	u16 capab_info, status_code, aid;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	int ac, uapsd_queues = -1;
+ 	u8 *pos;
+ 	bool reassoc;
+@@ -3724,14 +3735,16 @@ static void ieee80211_rx_mgmt_assoc_resp
+ 	    fils_decrypt_assoc_resp(sdata, (u8 *)mgmt, &len, assoc_data) < 0)
+ 		return;
+ 
+-	ieee802_11_parse_elems(pos, len - (pos - (u8 *)mgmt), false, &elems,
+-			       mgmt->bssid, assoc_data->bss->bssid);
++	elems = ieee802_11_parse_elems(pos, len - (pos - (u8 *)mgmt), false,
++				       mgmt->bssid, assoc_data->bss->bssid);
++	if (!elems)
++		goto notify_driver;
+ 
+ 	if (status_code == WLAN_STATUS_ASSOC_REJECTED_TEMPORARILY &&
+-	    elems.timeout_int &&
+-	    elems.timeout_int->type == WLAN_TIMEOUT_ASSOC_COMEBACK) {
++	    elems->timeout_int &&
++	    elems->timeout_int->type == WLAN_TIMEOUT_ASSOC_COMEBACK) {
+ 		u32 tu, ms;
+-		tu = le32_to_cpu(elems.timeout_int->value);
++		tu = le32_to_cpu(elems->timeout_int->value);
+ 		ms = tu * 1024 / 1000;
+ 		sdata_info(sdata,
+ 			   "%pM rejected association temporarily; comeback duration %u TU (%u ms)\n",
+@@ -3751,7 +3764,7 @@ static void ieee80211_rx_mgmt_assoc_resp
+ 		event.u.mlme.reason = status_code;
+ 		drv_event_callback(sdata->local, sdata, &event);
+ 	} else {
+-		if (!ieee80211_assoc_success(sdata, cbss, mgmt, len, &elems)) {
++		if (!ieee80211_assoc_success(sdata, cbss, mgmt, len, elems)) {
+ 			/* oops -- internal error -- send timeout for now */
+ 			ieee80211_destroy_assoc_data(sdata, false, false);
+ 			cfg80211_assoc_timeout(sdata->dev, cbss);
+@@ -3781,6 +3794,7 @@ static void ieee80211_rx_mgmt_assoc_resp
+ 			       ifmgd->assoc_req_ies, ifmgd->assoc_req_ies_len);
+ notify_driver:
+ 	drv_mgd_complete_tx(sdata->local, sdata, &info);
++	kfree(elems);
+ }
+ 
+ static void ieee80211_rx_bss_info(struct ieee80211_sub_if_data *sdata,
+@@ -3985,7 +3999,7 @@ static void ieee80211_rx_mgmt_beacon(str
+ 	struct ieee80211_bss_conf *bss_conf = &sdata->vif.bss_conf;
+ 	struct ieee80211_mgmt *mgmt = (void *) hdr;
+ 	size_t baselen;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	struct ieee80211_local *local = sdata->local;
+ 	struct ieee80211_chanctx_conf *chanctx_conf;
+ 	struct ieee80211_channel *chan;
+@@ -4031,15 +4045,16 @@ static void ieee80211_rx_mgmt_beacon(str
+ 
+ 	if (ifmgd->assoc_data && ifmgd->assoc_data->need_beacon &&
+ 	    ieee80211_rx_our_beacon(bssid, ifmgd->assoc_data->bss)) {
+-		ieee802_11_parse_elems(variable,
+-				       len - baselen, false, &elems,
+-				       bssid,
+-				       ifmgd->assoc_data->bss->bssid);
++		elems = ieee802_11_parse_elems(variable, len - baselen, false,
++					       bssid,
++					       ifmgd->assoc_data->bss->bssid);
++		if (!elems)
++			return;
+ 
+ 		ieee80211_rx_bss_info(sdata, mgmt, len, rx_status);
+ 
+-		if (elems.dtim_period)
+-			ifmgd->dtim_period = elems.dtim_period;
++		if (elems->dtim_period)
++			ifmgd->dtim_period = elems->dtim_period;
+ 		ifmgd->have_beacon = true;
+ 		ifmgd->assoc_data->need_beacon = false;
+ 		if (ieee80211_hw_check(&local->hw, TIMING_BEACON_ONLY)) {
+@@ -4047,17 +4062,17 @@ static void ieee80211_rx_mgmt_beacon(str
+ 				le64_to_cpu(mgmt->u.beacon.timestamp);
+ 			sdata->vif.bss_conf.sync_device_ts =
+ 				rx_status->device_timestamp;
+-			sdata->vif.bss_conf.sync_dtim_count = elems.dtim_count;
++			sdata->vif.bss_conf.sync_dtim_count = elems->dtim_count;
+ 		}
+ 
+-		if (elems.mbssid_config_ie)
++		if (elems->mbssid_config_ie)
+ 			bss_conf->profile_periodicity =
+-				elems.mbssid_config_ie->profile_periodicity;
++				elems->mbssid_config_ie->profile_periodicity;
+ 		else
+ 			bss_conf->profile_periodicity = 0;
+ 
+-		if (elems.ext_capab_len >= 11 &&
+-		    (elems.ext_capab[10] & WLAN_EXT_CAPA11_EMA_SUPPORT))
++		if (elems->ext_capab_len >= 11 &&
++		    (elems->ext_capab[10] & WLAN_EXT_CAPA11_EMA_SUPPORT))
+ 			bss_conf->ema_ap = true;
+ 		else
+ 			bss_conf->ema_ap = false;
+@@ -4066,6 +4081,7 @@ static void ieee80211_rx_mgmt_beacon(str
+ 		ifmgd->assoc_data->timeout = jiffies;
+ 		ifmgd->assoc_data->timeout_started = true;
+ 		run_again(sdata, ifmgd->assoc_data->timeout);
++		kfree(elems);
+ 		return;
+ 	}
+ 
+@@ -4097,14 +4113,15 @@ static void ieee80211_rx_mgmt_beacon(str
+ 	 */
+ 	if (!ieee80211_is_s1g_beacon(hdr->frame_control))
+ 		ncrc = crc32_be(0, (void *)&mgmt->u.beacon.beacon_int, 4);
+-	ieee802_11_parse_elems_crc(variable,
+-				   len - baselen, false, &elems,
+-				   care_about_ies, ncrc,
+-				   mgmt->bssid, bssid);
+-	ncrc = elems.crc;
++	elems = ieee802_11_parse_elems_crc(variable, len - baselen,
++					   false, care_about_ies, ncrc,
++					   mgmt->bssid, bssid);
++	if (!elems)
++		return;
++	ncrc = elems->crc;
+ 
+ 	if (ieee80211_hw_check(&local->hw, PS_NULLFUNC_STACK) &&
+-	    ieee80211_check_tim(elems.tim, elems.tim_len, bss_conf->aid)) {
++	    ieee80211_check_tim(elems->tim, elems->tim_len, bss_conf->aid)) {
+ 		if (local->hw.conf.dynamic_ps_timeout > 0) {
+ 			if (local->hw.conf.flags & IEEE80211_CONF_PS) {
+ 				local->hw.conf.flags &= ~IEEE80211_CONF_PS;
+@@ -4174,12 +4191,12 @@ static void ieee80211_rx_mgmt_beacon(str
+ 			le64_to_cpu(mgmt->u.beacon.timestamp);
+ 		sdata->vif.bss_conf.sync_device_ts =
+ 			rx_status->device_timestamp;
+-		sdata->vif.bss_conf.sync_dtim_count = elems.dtim_count;
++		sdata->vif.bss_conf.sync_dtim_count = elems->dtim_count;
+ 	}
+ 
+ 	if ((ncrc == ifmgd->beacon_crc && ifmgd->beacon_crc_valid) ||
+ 	    ieee80211_is_s1g_short_beacon(mgmt->frame_control))
+-		return;
++		goto free;
+ 	ifmgd->beacon_crc = ncrc;
+ 	ifmgd->beacon_crc_valid = true;
+ 
+@@ -4187,12 +4204,12 @@ static void ieee80211_rx_mgmt_beacon(str
+ 
+ 	ieee80211_sta_process_chanswitch(sdata, rx_status->mactime,
+ 					 rx_status->device_timestamp,
+-					 &elems, true);
++					 elems, true);
+ 
+ 	if (!(ifmgd->flags & IEEE80211_STA_DISABLE_WMM) &&
+-	    ieee80211_sta_wmm_params(local, sdata, elems.wmm_param,
+-				     elems.wmm_param_len,
+-				     elems.mu_edca_param_set))
++	    ieee80211_sta_wmm_params(local, sdata, elems->wmm_param,
++				     elems->wmm_param_len,
++				     elems->mu_edca_param_set))
+ 		changed |= BSS_CHANGED_QOS;
+ 
+ 	/*
+@@ -4201,7 +4218,7 @@ static void ieee80211_rx_mgmt_beacon(str
+ 	 */
+ 	if (!ifmgd->have_beacon) {
+ 		/* a few bogus AP send dtim_period = 0 or no TIM IE */
+-		bss_conf->dtim_period = elems.dtim_period ?: 1;
++		bss_conf->dtim_period = elems->dtim_period ?: 1;
+ 
+ 		changed |= BSS_CHANGED_BEACON_INFO;
+ 		ifmgd->have_beacon = true;
+@@ -4213,9 +4230,9 @@ static void ieee80211_rx_mgmt_beacon(str
+ 		ieee80211_recalc_ps_vif(sdata);
+ 	}
+ 
+-	if (elems.erp_info) {
++	if (elems->erp_info) {
+ 		erp_valid = true;
+-		erp_value = elems.erp_info[0];
++		erp_value = elems->erp_info[0];
+ 	} else {
+ 		erp_valid = false;
+ 	}
+@@ -4228,12 +4245,12 @@ static void ieee80211_rx_mgmt_beacon(str
+ 	mutex_lock(&local->sta_mtx);
+ 	sta = sta_info_get(sdata, bssid);
+ 
+-	changed |= ieee80211_recalc_twt_req(sdata, sta, &elems);
++	changed |= ieee80211_recalc_twt_req(sdata, sta, elems);
+ 
+-	if (ieee80211_config_bw(sdata, sta, elems.ht_cap_elem,
+-				elems.vht_cap_elem, elems.ht_operation,
+-				elems.vht_operation, elems.he_operation,
+-				elems.s1g_oper, bssid, &changed)) {
++	if (ieee80211_config_bw(sdata, sta, elems->ht_cap_elem,
++				elems->vht_cap_elem, elems->ht_operation,
++				elems->vht_operation, elems->he_operation,
++				elems->s1g_oper, bssid, &changed)) {
+ 		mutex_unlock(&local->sta_mtx);
+ 		sdata_info(sdata,
+ 			   "failed to follow AP %pM bandwidth change, disconnect\n",
+@@ -4245,21 +4262,23 @@ static void ieee80211_rx_mgmt_beacon(str
+ 					    sizeof(deauth_buf), true,
+ 					    WLAN_REASON_DEAUTH_LEAVING,
+ 					    false);
+-		return;
++		goto free;
+ 	}
+ 
+-	if (sta && elems.opmode_notif)
+-		ieee80211_vht_handle_opmode(sdata, sta, *elems.opmode_notif,
++	if (sta && elems->opmode_notif)
++		ieee80211_vht_handle_opmode(sdata, sta, *elems->opmode_notif,
+ 					    rx_status->band);
+ 	mutex_unlock(&local->sta_mtx);
+ 
+ 	changed |= ieee80211_handle_pwr_constr(sdata, chan, mgmt,
+-					       elems.country_elem,
+-					       elems.country_elem_len,
+-					       elems.pwr_constr_elem,
+-					       elems.cisco_dtpc_elem);
++					       elems->country_elem,
++					       elems->country_elem_len,
++					       elems->pwr_constr_elem,
++					       elems->cisco_dtpc_elem);
+ 
+ 	ieee80211_bss_info_change_notify(sdata, changed);
++free:
++	kfree(elems);
+ }
+ 
+ void ieee80211_sta_rx_queued_ext(struct ieee80211_sub_if_data *sdata,
+@@ -4288,7 +4307,6 @@ void ieee80211_sta_rx_queued_mgmt(struct
+ 	struct ieee80211_rx_status *rx_status;
+ 	struct ieee80211_mgmt *mgmt;
+ 	u16 fc;
+-	struct ieee802_11_elems elems;
+ 	int ies_len;
+ 
+ 	rx_status = (struct ieee80211_rx_status *) skb->cb;
+@@ -4320,6 +4338,8 @@ void ieee80211_sta_rx_queued_mgmt(struct
+ 		break;
+ 	case IEEE80211_STYPE_ACTION:
+ 		if (mgmt->u.action.category == WLAN_CATEGORY_SPECTRUM_MGMT) {
++			struct ieee802_11_elems *elems;
++
+ 			ies_len = skb->len -
+ 				  offsetof(struct ieee80211_mgmt,
+ 					   u.action.u.chan_switch.variable);
+@@ -4328,18 +4348,21 @@ void ieee80211_sta_rx_queued_mgmt(struct
+ 				break;
+ 
+ 			/* CSA IE cannot be overridden, no need for BSSID */
+-			ieee802_11_parse_elems(
+-				mgmt->u.action.u.chan_switch.variable,
+-				ies_len, true, &elems, mgmt->bssid, NULL);
++			elems = ieee802_11_parse_elems(
++					mgmt->u.action.u.chan_switch.variable,
++					ies_len, true, mgmt->bssid, NULL);
+ 
+-			if (elems.parse_error)
++			if (!elems || elems->parse_error)
+ 				break;
+ 
+ 			ieee80211_sta_process_chanswitch(sdata,
+ 						 rx_status->mactime,
+ 						 rx_status->device_timestamp,
+-						 &elems, false);
++						 elems, false);
++			kfree(elems);
+ 		} else if (mgmt->u.action.category == WLAN_CATEGORY_PUBLIC) {
++			struct ieee802_11_elems *elems;
++
+ 			ies_len = skb->len -
+ 				  offsetof(struct ieee80211_mgmt,
+ 					   u.action.u.ext_chan_switch.variable);
+@@ -4351,21 +4374,22 @@ void ieee80211_sta_rx_queued_mgmt(struct
+ 			 * extended CSA IE can't be overridden, no need for
+ 			 * BSSID
+ 			 */
+-			ieee802_11_parse_elems(
+-				mgmt->u.action.u.ext_chan_switch.variable,
+-				ies_len, true, &elems, mgmt->bssid, NULL);
++			elems = ieee802_11_parse_elems(
++					mgmt->u.action.u.ext_chan_switch.variable,
++					ies_len, true, mgmt->bssid, NULL);
+ 
+-			if (elems.parse_error)
++			if (!elems || elems->parse_error)
+ 				break;
+ 
+ 			/* for the handling code pretend this was also an IE */
+-			elems.ext_chansw_ie =
++			elems->ext_chansw_ie =
+ 				&mgmt->u.action.u.ext_chan_switch.data;
+ 
+ 			ieee80211_sta_process_chanswitch(sdata,
+ 						 rx_status->mactime,
+ 						 rx_status->device_timestamp,
+-						 &elems, false);
++						 elems, false);
++			kfree(elems);
+ 		}
+ 		break;
+ 	}
+--- a/net/mac80211/scan.c
++++ b/net/mac80211/scan.c
+@@ -9,7 +9,7 @@
+  * Copyright 2007, Michael Wu <flamingice@sourmilk.net>
+  * Copyright 2013-2015  Intel Mobile Communications GmbH
+  * Copyright 2016-2017  Intel Deutschland GmbH
+- * Copyright (C) 2018-2020 Intel Corporation
++ * Copyright (C) 2018-2021 Intel Corporation
+  */
+ 
+ #include <linux/if_arp.h>
+@@ -155,7 +155,7 @@ ieee80211_bss_info_update(struct ieee802
+ 	};
+ 	bool signal_valid;
+ 	struct ieee80211_sub_if_data *scan_sdata;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	size_t baselen;
+ 	u8 *elements;
+ 
+@@ -209,8 +209,10 @@ ieee80211_bss_info_update(struct ieee802
+ 	if (baselen > len)
+ 		return NULL;
+ 
+-	ieee802_11_parse_elems(elements, len - baselen, false, &elems,
+-			       mgmt->bssid, cbss->bssid);
++	elems = ieee802_11_parse_elems(elements, len - baselen, false,
++				       mgmt->bssid, cbss->bssid);
++	if (!elems)
++		return NULL;
+ 
+ 	/* In case the signal is invalid update the status */
+ 	signal_valid = channel == cbss->channel;
+@@ -218,15 +220,17 @@ ieee80211_bss_info_update(struct ieee802
+ 		rx_status->flag |= RX_FLAG_NO_SIGNAL_VAL;
+ 
+ 	bss = (void *)cbss->priv;
+-	ieee80211_update_bss_from_elems(local, bss, &elems, rx_status, beacon);
++	ieee80211_update_bss_from_elems(local, bss, elems, rx_status, beacon);
+ 
+ 	list_for_each_entry(non_tx_cbss, &cbss->nontrans_list, nontrans_list) {
+ 		non_tx_bss = (void *)non_tx_cbss->priv;
+ 
+-		ieee80211_update_bss_from_elems(local, non_tx_bss, &elems,
++		ieee80211_update_bss_from_elems(local, non_tx_bss, elems,
+ 						rx_status, beacon);
+ 	}
+ 
++	kfree(elems);
++
+ 	return bss;
+ }
+ 
+--- a/net/mac80211/tdls.c
++++ b/net/mac80211/tdls.c
+@@ -6,7 +6,7 @@
+  * Copyright 2014, Intel Corporation
+  * Copyright 2014  Intel Mobile Communications GmbH
+  * Copyright 2015 - 2016 Intel Deutschland GmbH
+- * Copyright (C) 2019 Intel Corporation
++ * Copyright (C) 2019, 2021 Intel Corporation
+  */
+ 
+ #include <linux/ieee80211.h>
+@@ -1684,7 +1684,7 @@ ieee80211_process_tdls_channel_switch_re
+ 					   struct sk_buff *skb)
+ {
+ 	struct ieee80211_local *local = sdata->local;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems = NULL;
+ 	struct sta_info *sta;
+ 	struct ieee80211_tdls_data *tf = (void *)skb->data;
+ 	bool local_initiator;
+@@ -1718,16 +1718,20 @@ ieee80211_process_tdls_channel_switch_re
+ 		goto call_drv;
+ 	}
+ 
+-	ieee802_11_parse_elems(tf->u.chan_switch_resp.variable,
+-			       skb->len - baselen, false, &elems,
+-			       NULL, NULL);
+-	if (elems.parse_error) {
++	elems = ieee802_11_parse_elems(tf->u.chan_switch_resp.variable,
++				       skb->len - baselen, false, NULL, NULL);
++	if (!elems) {
++		ret = -ENOMEM;
++		goto out;
++	}
++
++	if (elems->parse_error) {
+ 		tdls_dbg(sdata, "Invalid IEs in TDLS channel switch resp\n");
+ 		ret = -EINVAL;
+ 		goto out;
+ 	}
+ 
+-	if (!elems.ch_sw_timing || !elems.lnk_id) {
++	if (!elems->ch_sw_timing || !elems->lnk_id) {
+ 		tdls_dbg(sdata, "TDLS channel switch resp - missing IEs\n");
+ 		ret = -EINVAL;
+ 		goto out;
+@@ -1735,15 +1739,15 @@ ieee80211_process_tdls_channel_switch_re
+ 
+ 	/* validate the initiator is set correctly */
+ 	local_initiator =
+-		!memcmp(elems.lnk_id->init_sta, sdata->vif.addr, ETH_ALEN);
++		!memcmp(elems->lnk_id->init_sta, sdata->vif.addr, ETH_ALEN);
+ 	if (local_initiator == sta->sta.tdls_initiator) {
+ 		tdls_dbg(sdata, "TDLS chan switch invalid lnk-id initiator\n");
+ 		ret = -EINVAL;
+ 		goto out;
+ 	}
+ 
+-	params.switch_time = le16_to_cpu(elems.ch_sw_timing->switch_time);
+-	params.switch_timeout = le16_to_cpu(elems.ch_sw_timing->switch_timeout);
++	params.switch_time = le16_to_cpu(elems->ch_sw_timing->switch_time);
++	params.switch_timeout = le16_to_cpu(elems->ch_sw_timing->switch_timeout);
+ 
+ 	params.tmpl_skb =
+ 		ieee80211_tdls_ch_sw_resp_tmpl_get(sta, &params.ch_sw_tm_ie);
+@@ -1763,6 +1767,7 @@ call_drv:
+ out:
+ 	mutex_unlock(&local->sta_mtx);
+ 	dev_kfree_skb_any(params.tmpl_skb);
++	kfree(elems);
+ 	return ret;
+ }
+ 
+@@ -1771,7 +1776,7 @@ ieee80211_process_tdls_channel_switch_re
+ 					  struct sk_buff *skb)
+ {
+ 	struct ieee80211_local *local = sdata->local;
+-	struct ieee802_11_elems elems;
++	struct ieee802_11_elems *elems;
+ 	struct cfg80211_chan_def chandef;
+ 	struct ieee80211_channel *chan;
+ 	enum nl80211_channel_type chan_type;
+@@ -1831,22 +1836,27 @@ ieee80211_process_tdls_channel_switch_re
+ 		return -EINVAL;
+ 	}
+ 
+-	ieee802_11_parse_elems(tf->u.chan_switch_req.variable,
+-			       skb->len - baselen, false, &elems, NULL, NULL);
+-	if (elems.parse_error) {
++	elems = ieee802_11_parse_elems(tf->u.chan_switch_req.variable,
++				       skb->len - baselen, false, NULL, NULL);
++	if (!elems)
++		return -ENOMEM;
++
++	if (elems->parse_error) {
+ 		tdls_dbg(sdata, "Invalid IEs in TDLS channel switch req\n");
+-		return -EINVAL;
++		ret = -EINVAL;
++		goto free;
+ 	}
+ 
+-	if (!elems.ch_sw_timing || !elems.lnk_id) {
++	if (!elems->ch_sw_timing || !elems->lnk_id) {
+ 		tdls_dbg(sdata, "TDLS channel switch req - missing IEs\n");
+-		return -EINVAL;
++		ret = -EINVAL;
++		goto free;
+ 	}
+ 
+-	if (!elems.sec_chan_offs) {
++	if (!elems->sec_chan_offs) {
+ 		chan_type = NL80211_CHAN_HT20;
+ 	} else {
+-		switch (elems.sec_chan_offs->sec_chan_offs) {
++		switch (elems->sec_chan_offs->sec_chan_offs) {
+ 		case IEEE80211_HT_PARAM_CHA_SEC_ABOVE:
+ 			chan_type = NL80211_CHAN_HT40PLUS;
+ 			break;
+@@ -1865,7 +1875,8 @@ ieee80211_process_tdls_channel_switch_re
+ 	if (!cfg80211_reg_can_beacon_relax(sdata->local->hw.wiphy, &chandef,
+ 					   sdata->wdev.iftype)) {
+ 		tdls_dbg(sdata, "TDLS chan switch to forbidden channel\n");
+-		return -EINVAL;
++		ret = -EINVAL;
++		goto free;
+ 	}
+ 
+ 	mutex_lock(&local->sta_mtx);
+@@ -1881,7 +1892,7 @@ ieee80211_process_tdls_channel_switch_re
+ 
+ 	/* validate the initiator is set correctly */
+ 	local_initiator =
+-		!memcmp(elems.lnk_id->init_sta, sdata->vif.addr, ETH_ALEN);
++		!memcmp(elems->lnk_id->init_sta, sdata->vif.addr, ETH_ALEN);
+ 	if (local_initiator == sta->sta.tdls_initiator) {
+ 		tdls_dbg(sdata, "TDLS chan switch invalid lnk-id initiator\n");
+ 		ret = -EINVAL;
+@@ -1889,16 +1900,16 @@ ieee80211_process_tdls_channel_switch_re
+ 	}
+ 
+ 	/* peer should have known better */
+-	if (!sta->sta.ht_cap.ht_supported && elems.sec_chan_offs &&
+-	    elems.sec_chan_offs->sec_chan_offs) {
++	if (!sta->sta.ht_cap.ht_supported && elems->sec_chan_offs &&
++	    elems->sec_chan_offs->sec_chan_offs) {
+ 		tdls_dbg(sdata, "TDLS chan switch - wide chan unsupported\n");
+ 		ret = -ENOTSUPP;
+ 		goto out;
+ 	}
+ 
+ 	params.chandef = &chandef;
+-	params.switch_time = le16_to_cpu(elems.ch_sw_timing->switch_time);
+-	params.switch_timeout = le16_to_cpu(elems.ch_sw_timing->switch_timeout);
++	params.switch_time = le16_to_cpu(elems->ch_sw_timing->switch_time);
++	params.switch_timeout = le16_to_cpu(elems->ch_sw_timing->switch_timeout);
+ 
+ 	params.tmpl_skb =
+ 		ieee80211_tdls_ch_sw_resp_tmpl_get(sta,
+@@ -1917,6 +1928,8 @@ ieee80211_process_tdls_channel_switch_re
+ out:
+ 	mutex_unlock(&local->sta_mtx);
+ 	dev_kfree_skb_any(params.tmpl_skb);
++free:
++	kfree(elems);
+ 	return ret;
+ }
+ 
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1399,8 +1399,8 @@ _ieee802_11_parse_elems_crc(const u8 *st
+ 
+ static size_t ieee802_11_find_bssid_profile(const u8 *start, size_t len,
+ 					    struct ieee802_11_elems *elems,
+-					    u8 *transmitter_bssid,
+-					    u8 *bss_bssid,
++					    const u8 *transmitter_bssid,
++					    const u8 *bss_bssid,
+ 					    u8 *nontransmitted_profile)
+ {
+ 	const struct element *elem, *sub;
+@@ -1465,16 +1465,20 @@ static size_t ieee802_11_find_bssid_prof
+ 	return found ? profile_len : 0;
+ }
+ 
+-void ieee802_11_parse_elems_crc(const u8 *start, size_t len, bool action,
+-				struct ieee802_11_elems *elems,
+-				u64 filter, u32 crc, u8 *transmitter_bssid,
+-				u8 *bss_bssid)
++struct ieee802_11_elems *ieee802_11_parse_elems_crc(const u8 *start, size_t len,
++						    bool action, u64 filter,
++						    u32 crc,
++						    const u8 *transmitter_bssid,
++						    const u8 *bss_bssid)
+ {
++	struct ieee802_11_elems *elems;
+ 	const struct element *non_inherit = NULL;
+ 	u8 *nontransmitted_profile;
+ 	int nontransmitted_profile_len = 0;
+ 
+-	memset(elems, 0, sizeof(*elems));
++	elems = kzalloc(sizeof(*elems), GFP_ATOMIC);
++	if (!elems)
++		return NULL;
+ 	elems->ie_start = start;
+ 	elems->total_len = len;
+ 
+@@ -1521,6 +1525,8 @@ void ieee802_11_parse_elems_crc(const u8
+ 	kfree(nontransmitted_profile);
+ 
+ 	elems->crc = crc;
++
++	return elems;
+ }
+ 
+ void ieee80211_regulatory_limit_wmm_params(struct ieee80211_sub_if_data *sdata,

--- a/package/kernel/mac80211/patches/subsys/350-mac80211-fix-memory-leaks-with-element-parsing.patch
+++ b/package/kernel/mac80211/patches/subsys/350-mac80211-fix-memory-leaks-with-element-parsing.patch
@@ -1,0 +1,115 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Fri, 1 Oct 2021 21:11:08 +0200
+Subject: [PATCH] mac80211: fix memory leaks with element parsing
+
+commit 8223ac199a3849257e86ec27865dc63f034b1cf1 upstream.
+
+My previous commit 5d24828d05f3 ("mac80211: always allocate
+struct ieee802_11_elems") had a few bugs and leaked the new
+allocated struct in a few error cases, fix that.
+
+Fixes: 5d24828d05f3 ("mac80211: always allocate struct ieee802_11_elems")
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+Link: https://lore.kernel.org/r/20211001211108.9839928e42e0.Ib81ca187d3d3af7ed1bfeac2e00d08a4637c8025@changeid
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/agg-rx.c
++++ b/net/mac80211/agg-rx.c
+@@ -499,13 +499,14 @@ void ieee80211_process_addba_request(str
+ 		elems = ieee802_11_parse_elems(mgmt->u.action.u.addba_req.variable,
+ 					       ies_len, true, mgmt->bssid, NULL);
+ 		if (!elems || elems->parse_error)
+-			return;
++			goto free;
+ 	}
+ 
+ 	__ieee80211_start_rx_ba_session(sta, dialog_token, timeout,
+ 					start_seq_num, ba_policy, tid,
+ 					buf_size, true, false,
+ 					elems ? elems->addba_ext_ie : NULL);
++free:
+ 	kfree(elems);
+ }
+ 
+--- a/net/mac80211/ibss.c
++++ b/net/mac80211/ibss.c
+@@ -1659,11 +1659,11 @@ void ieee80211_ibss_rx_queued_mgmt(struc
+ 				mgmt->u.action.u.chan_switch.variable,
+ 				ies_len, true, mgmt->bssid, NULL);
+ 
+-			if (!elems || elems->parse_error)
+-				break;
+-
+-			ieee80211_rx_mgmt_spectrum_mgmt(sdata, mgmt, skb->len,
+-							rx_status, elems);
++			if (elems && !elems->parse_error)
++				ieee80211_rx_mgmt_spectrum_mgmt(sdata, mgmt,
++								skb->len,
++								rx_status,
++								elems);
+ 			kfree(elems);
+ 			break;
+ 		}
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -3374,8 +3374,10 @@ static bool ieee80211_assoc_success(stru
+ 			bss_ies = kmemdup(ies, sizeof(*ies) + ies->len,
+ 					  GFP_ATOMIC);
+ 		rcu_read_unlock();
+-		if (!bss_ies)
+-			return false;
++		if (!bss_ies) {
++			ret = false;
++			goto out;
++		}
+ 
+ 		bss_elems = ieee802_11_parse_elems(bss_ies->data, bss_ies->len,
+ 						   false, mgmt->bssid,
+@@ -4352,13 +4354,11 @@ void ieee80211_sta_rx_queued_mgmt(struct
+ 					mgmt->u.action.u.chan_switch.variable,
+ 					ies_len, true, mgmt->bssid, NULL);
+ 
+-			if (!elems || elems->parse_error)
+-				break;
+-
+-			ieee80211_sta_process_chanswitch(sdata,
+-						 rx_status->mactime,
+-						 rx_status->device_timestamp,
+-						 elems, false);
++			if (elems && !elems->parse_error)
++				ieee80211_sta_process_chanswitch(sdata,
++								 rx_status->mactime,
++								 rx_status->device_timestamp,
++								 elems, false);
+ 			kfree(elems);
+ 		} else if (mgmt->u.action.category == WLAN_CATEGORY_PUBLIC) {
+ 			struct ieee802_11_elems *elems;
+@@ -4378,17 +4378,17 @@ void ieee80211_sta_rx_queued_mgmt(struct
+ 					mgmt->u.action.u.ext_chan_switch.variable,
+ 					ies_len, true, mgmt->bssid, NULL);
+ 
+-			if (!elems || elems->parse_error)
+-				break;
++			if (elems && !elems->parse_error) {
++				/* for the handling code pretend it was an IE */
++				elems->ext_chansw_ie =
++					&mgmt->u.action.u.ext_chan_switch.data;
++
++				ieee80211_sta_process_chanswitch(sdata,
++								 rx_status->mactime,
++								 rx_status->device_timestamp,
++								 elems, false);
++			}
+ 
+-			/* for the handling code pretend this was also an IE */
+-			elems->ext_chansw_ie =
+-				&mgmt->u.action.u.ext_chan_switch.data;
+-
+-			ieee80211_sta_process_chanswitch(sdata,
+-						 rx_status->mactime,
+-						 rx_status->device_timestamp,
+-						 elems, false);
+ 			kfree(elems);
+ 		}
+ 		break;

--- a/package/kernel/mac80211/patches/subsys/351-wifi-cfg80211-fix-u8-overflow-in-cfg80211_update_not.patch
+++ b/package/kernel/mac80211/patches/subsys/351-wifi-cfg80211-fix-u8-overflow-in-cfg80211_update_not.patch
@@ -1,0 +1,41 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Wed, 28 Sep 2022 21:56:15 +0200
+Subject: [PATCH] wifi: cfg80211: fix u8 overflow in
+ cfg80211_update_notlisted_nontrans()
+
+commit aebe9f4639b13a1f4e9a6b42cdd2e38c617b442d upstream.
+
+In the copy code of the elements, we do the following calculation
+to reach the end of the MBSSID element:
+
+	/* copy the IEs after MBSSID */
+	cpy_len = mbssid[1] + 2;
+
+This looks fine, however, cpy_len is a u8, the same as mbssid[1],
+so the addition of two can overflow. In this case the subsequent
+memcpy() will overflow the allocated buffer, since it copies 256
+bytes too much due to the way the allocation and memcpy() sizes
+are calculated.
+
+Fix this by using size_t for the cpy_len variable.
+
+This fixes CVE-2022-41674.
+
+Reported-by: Soenke Huster <shuster@seemoo.tu-darmstadt.de>
+Tested-by: Soenke Huster <shuster@seemoo.tu-darmstadt.de>
+Fixes: 0b8fb8235be8 ("cfg80211: Parsing of Multiple BSSID information in scanning")
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/wireless/scan.c
++++ b/net/wireless/scan.c
+@@ -2229,7 +2229,7 @@ cfg80211_update_notlisted_nontrans(struc
+ 	size_t new_ie_len;
+ 	struct cfg80211_bss_ies *new_ies;
+ 	const struct cfg80211_bss_ies *old;
+-	u8 cpy_len;
++	size_t cpy_len;
+ 
+ 	lockdep_assert_held(&wiphy_to_rdev(wiphy)->bss_lock);
+ 

--- a/package/kernel/mac80211/patches/subsys/352-wifi-cfg80211-mac80211-reject-bad-MBSSID-elements.patch
+++ b/package/kernel/mac80211/patches/subsys/352-wifi-cfg80211-mac80211-reject-bad-MBSSID-elements.patch
@@ -1,0 +1,47 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Wed, 28 Sep 2022 22:01:37 +0200
+Subject: [PATCH] wifi: cfg80211/mac80211: reject bad MBSSID elements
+
+commit 8f033d2becc24aa6bfd2a5c104407963560caabc upstream
+
+Per spec, the maximum value for the MaxBSSID ('n') indicator is 8,
+and the minimum is 1 since a multiple BSSID set with just one BSSID
+doesn't make sense (the # of BSSIDs is limited by 2^n).
+
+Limit this in the parsing in both cfg80211 and mac80211, rejecting
+any elements with an invalid value.
+
+This fixes potentially bad shifts in the processing of these inside
+the cfg80211_gen_new_bssid() function later.
+
+I found this during the investigation of CVE-2022-41674 fixed by the
+previous patch.
+
+Fixes: 0b8fb8235be8 ("cfg80211: Parsing of Multiple BSSID information in scanning")
+Fixes: 78ac51f81532 ("mac80211: support multi-bssid")
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1413,6 +1413,8 @@ static size_t ieee802_11_find_bssid_prof
+ 	for_each_element_id(elem, WLAN_EID_MULTIPLE_BSSID, start, len) {
+ 		if (elem->datalen < 2)
+ 			continue;
++		if (elem->data[0] < 1 || elem->data[0] > 8)
++			continue;
+ 
+ 		for_each_element(sub, elem->data + 1, elem->datalen - 1) {
+ 			u8 new_bssid[ETH_ALEN];
+--- a/net/wireless/scan.c
++++ b/net/wireless/scan.c
+@@ -2094,6 +2094,8 @@ static void cfg80211_parse_mbssid_data(s
+ 	for_each_element_id(elem, WLAN_EID_MULTIPLE_BSSID, ie, ielen) {
+ 		if (elem->datalen < 4)
+ 			continue;
++		if (elem->data[0] < 1 || (int)elem->data[0] > 8)
++			continue;
+ 		for_each_element(sub, elem->data + 1, elem->datalen - 1) {
+ 			u8 profile_len;
+ 

--- a/package/kernel/mac80211/patches/subsys/353-wifi-mac80211-fix-MBSSID-parsing-use-after-free.patch
+++ b/package/kernel/mac80211/patches/subsys/353-wifi-mac80211-fix-MBSSID-parsing-use-after-free.patch
@@ -1,0 +1,94 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Wed, 28 Sep 2022 22:07:15 +0200
+Subject: [PATCH] wifi: mac80211: fix MBSSID parsing use-after-free
+
+commit ff05d4b45dd89b922578dac497dcabf57cf771c6
+
+When we parse a multi-BSSID element, we might point some
+element pointers into the allocated nontransmitted_profile.
+However, we free this before returning, causing UAF when the
+relevant pointers in the parsed elements are accessed.
+
+Fix this by not allocating the scratch buffer separately but
+as part of the returned structure instead, that way, there
+are no lifetime issues with it.
+
+The scratch buffer introduction as part of the returned data
+here is taken from MLO feature work done by Ilan.
+
+This fixes CVE-2022-42719.
+
+Fixes: 5023b14cf4df ("mac80211: support profile split between elements")
+Co-developed-by: Ilan Peer <ilan.peer@intel.com>
+Signed-off-by: Ilan Peer <ilan.peer@intel.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/ieee80211_i.h
++++ b/net/mac80211/ieee80211_i.h
+@@ -1606,6 +1606,14 @@ struct ieee802_11_elems {
+ 
+ 	/* whether a parse error occurred while retrieving these elements */
+ 	bool parse_error;
++
++	/*
++	 * scratch buffer that can be used for various element parsing related
++	 * tasks, e.g., element de-fragmentation etc.
++	 */
++	size_t scratch_len;
++	u8 *scratch_pos;
++	u8 scratch[];
+ };
+ 
+ static inline struct ieee80211_local *hw_to_local(
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1478,24 +1478,25 @@ struct ieee802_11_elems *ieee802_11_pars
+ 	u8 *nontransmitted_profile;
+ 	int nontransmitted_profile_len = 0;
+ 
+-	elems = kzalloc(sizeof(*elems), GFP_ATOMIC);
++	elems = kzalloc(sizeof(*elems) + len, GFP_ATOMIC);
+ 	if (!elems)
+ 		return NULL;
+ 	elems->ie_start = start;
+ 	elems->total_len = len;
+ 
+-	nontransmitted_profile = kmalloc(len, GFP_ATOMIC);
+-	if (nontransmitted_profile) {
+-		nontransmitted_profile_len =
+-			ieee802_11_find_bssid_profile(start, len, elems,
+-						      transmitter_bssid,
+-						      bss_bssid,
+-						      nontransmitted_profile);
+-		non_inherit =
+-			cfg80211_find_ext_elem(WLAN_EID_EXT_NON_INHERITANCE,
+-					       nontransmitted_profile,
+-					       nontransmitted_profile_len);
+-	}
++	elems->scratch_len = len;
++	elems->scratch_pos = elems->scratch;
++
++	nontransmitted_profile = elems->scratch_pos;
++	nontransmitted_profile_len =
++		ieee802_11_find_bssid_profile(start, len, elems,
++					      transmitter_bssid,
++					      bss_bssid,
++					      nontransmitted_profile);
++	non_inherit =
++		cfg80211_find_ext_elem(WLAN_EID_EXT_NON_INHERITANCE,
++				       nontransmitted_profile,
++				       nontransmitted_profile_len);
+ 
+ 	crc = _ieee802_11_parse_elems_crc(start, len, action, elems, filter,
+ 					  crc, non_inherit);
+@@ -1524,8 +1525,6 @@ struct ieee802_11_elems *ieee802_11_pars
+ 	    offsetofend(struct ieee80211_bssid_index, dtim_count))
+ 		elems->dtim_count = elems->bssid_index->dtim_count;
+ 
+-	kfree(nontransmitted_profile);
+-
+ 	elems->crc = crc;
+ 
+ 	return elems;

--- a/package/kernel/mac80211/patches/subsys/354-wifi-cfg80211-ensure-length-byte-is-present-before-a.patch
+++ b/package/kernel/mac80211/patches/subsys/354-wifi-cfg80211-ensure-length-byte-is-present-before-a.patch
@@ -1,0 +1,41 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Thu, 29 Sep 2022 21:50:44 +0200
+Subject: [PATCH] wifi: cfg80211: ensure length byte is present before
+ access
+
+commit 567e14e39e8f8c6997a1378bc3be615afca86063 upstream.
+
+When iterating the elements here, ensure the length byte is
+present before checking it to see if the entire element will
+fit into the buffer.
+
+Longer term, we should rewrite this code using the type-safe
+element iteration macros that check all of this.
+
+Fixes: 0b8fb8235be8 ("cfg80211: Parsing of Multiple BSSID information in scanning")
+Reported-by: Soenke Huster <shuster@seemoo.tu-darmstadt.de>
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/wireless/scan.c
++++ b/net/wireless/scan.c
+@@ -304,7 +304,8 @@ static size_t cfg80211_gen_new_ie(const
+ 	tmp_old = cfg80211_find_ie(WLAN_EID_SSID, ie, ielen);
+ 	tmp_old = (tmp_old) ? tmp_old + tmp_old[1] + 2 : ie;
+ 
+-	while (tmp_old + tmp_old[1] + 2 - ie <= ielen) {
++	while (tmp_old + 2 - ie <= ielen &&
++	       tmp_old + tmp_old[1] + 2 - ie <= ielen) {
+ 		if (tmp_old[0] == 0) {
+ 			tmp_old++;
+ 			continue;
+@@ -364,7 +365,8 @@ static size_t cfg80211_gen_new_ie(const
+ 	 * copied to new ie, skip ssid, capability, bssid-index ie
+ 	 */
+ 	tmp_new = sub_copy;
+-	while (tmp_new + tmp_new[1] + 2 - sub_copy <= subie_len) {
++	while (tmp_new + 2 - sub_copy <= subie_len &&
++	       tmp_new + tmp_new[1] + 2 - sub_copy <= subie_len) {
+ 		if (!(tmp_new[0] == WLAN_EID_NON_TX_BSSID_CAP ||
+ 		      tmp_new[0] == WLAN_EID_SSID)) {
+ 			memcpy(pos, tmp_new, tmp_new[1] + 2);

--- a/package/kernel/mac80211/patches/subsys/355-wifi-cfg80211-fix-BSS-refcounting-bugs.patch
+++ b/package/kernel/mac80211/patches/subsys/355-wifi-cfg80211-fix-BSS-refcounting-bugs.patch
@@ -1,0 +1,90 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Fri, 30 Sep 2022 23:44:23 +0200
+Subject: [PATCH] wifi: cfg80211: fix BSS refcounting bugs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit 0b7808818cb9df6680f98996b8e9a439fa7bcc2f upstream.
+
+There are multiple refcounting bugs related to multi-BSSID:
+ - In bss_ref_get(), if the BSS has a hidden_beacon_bss, then
+   the bss pointer is overwritten before checking for the
+   transmitted BSS, which is clearly wrong. Fix this by using
+   the bss_from_pub() macro.
+
+ - In cfg80211_bss_update() we copy the transmitted_bss pointer
+   from tmp into new, but then if we release new, we'll unref
+   it erroneously. We already set the pointer and ref it, but
+   need to NULL it since it was copied from the tmp data.
+
+ - In cfg80211_inform_single_bss_data(), if adding to the non-
+   transmitted list fails, we unlink the BSS and yet still we
+   return it, but this results in returning an entry without
+   a reference. We shouldn't return it anyway if it was broken
+   enough to not get added there.
+
+This fixes CVE-2022-42720.
+
+Reported-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Tested-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Fixes: a3584f56de1c ("cfg80211: Properly track transmitting and non-transmitting BSS")
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/wireless/scan.c
++++ b/net/wireless/scan.c
+@@ -143,18 +143,12 @@ static inline void bss_ref_get(struct cf
+ 	lockdep_assert_held(&rdev->bss_lock);
+ 
+ 	bss->refcount++;
+-	if (bss->pub.hidden_beacon_bss) {
+-		bss = container_of(bss->pub.hidden_beacon_bss,
+-				   struct cfg80211_internal_bss,
+-				   pub);
+-		bss->refcount++;
+-	}
+-	if (bss->pub.transmitted_bss) {
+-		bss = container_of(bss->pub.transmitted_bss,
+-				   struct cfg80211_internal_bss,
+-				   pub);
+-		bss->refcount++;
+-	}
++
++	if (bss->pub.hidden_beacon_bss)
++		bss_from_pub(bss->pub.hidden_beacon_bss)->refcount++;
++
++	if (bss->pub.transmitted_bss)
++		bss_from_pub(bss->pub.transmitted_bss)->refcount++;
+ }
+ 
+ static inline void bss_ref_put(struct cfg80211_registered_device *rdev,
+@@ -1736,6 +1730,8 @@ cfg80211_bss_update(struct cfg80211_regi
+ 		new->refcount = 1;
+ 		INIT_LIST_HEAD(&new->hidden_list);
+ 		INIT_LIST_HEAD(&new->pub.nontrans_list);
++		/* we'll set this later if it was non-NULL */
++		new->pub.transmitted_bss = NULL;
+ 
+ 		if (rcu_access_pointer(tmp->pub.proberesp_ies)) {
+ 			hidden = rb_find_bss(rdev, tmp, BSS_CMP_HIDE_ZLEN);
+@@ -1973,11 +1969,18 @@ cfg80211_inform_single_bss_data(struct w
+ 		/* this is a nontransmitting bss, we need to add it to
+ 		 * transmitting bss' list if it is not there
+ 		 */
++		spin_lock_bh(&rdev->bss_lock);
+ 		if (cfg80211_add_nontrans_list(non_tx_data->tx_bss,
+ 					       &res->pub)) {
+-			if (__cfg80211_unlink_bss(rdev, res))
++			if (__cfg80211_unlink_bss(rdev, res)) {
+ 				rdev->bss_generation++;
++				res = NULL;
++			}
+ 		}
++		spin_unlock_bh(&rdev->bss_lock);
++
++		if (!res)
++			return NULL;
+ 	}
+ 
+ 	trace_cfg80211_return_bss(&res->pub);

--- a/package/kernel/mac80211/patches/subsys/356-wifi-cfg80211-avoid-nontransmitted-BSS-list-corrupti.patch
+++ b/package/kernel/mac80211/patches/subsys/356-wifi-cfg80211-avoid-nontransmitted-BSS-list-corrupti.patch
@@ -1,0 +1,48 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Sat, 1 Oct 2022 00:01:44 +0200
+Subject: [PATCH] wifi: cfg80211: avoid nontransmitted BSS list
+ corruption
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit bcca852027e5878aec911a347407ecc88d6fff7f upstream.
+
+If a non-transmitted BSS shares enough information (both
+SSID and BSSID!) with another non-transmitted BSS of a
+different AP, then we can find and update it, and then
+try to add it to the non-transmitted BSS list. We do a
+search for it on the transmitted BSS, but if it's not
+there (but belongs to another transmitted BSS), the list
+gets corrupted.
+
+Since this is an erroneous situation, simply fail the
+list insertion in this case and free the non-transmitted
+BSS.
+
+This fixes CVE-2022-42721.
+
+Reported-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Tested-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Fixes: 0b8fb8235be8 ("cfg80211: Parsing of Multiple BSSID information in scanning")
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/wireless/scan.c
++++ b/net/wireless/scan.c
+@@ -425,6 +425,15 @@ cfg80211_add_nontrans_list(struct cfg802
+ 
+ 	rcu_read_unlock();
+ 
++	/*
++	 * This is a bit weird - it's not on the list, but already on another
++	 * one! The only way that could happen is if there's some BSSID/SSID
++	 * shared by multiple APs in their multi-BSSID profiles, potentially
++	 * with hidden SSID mixed in ... ignore it.
++	 */
++	if (!list_empty(&nontrans_bss->nontrans_list))
++		return -EINVAL;
++
+ 	/* add to the list */
+ 	list_add_tail(&nontrans_bss->nontrans_list, &trans_bss->nontrans_list);
+ 	return 0;

--- a/package/kernel/mac80211/patches/subsys/357-wifi-mac80211_hwsim-avoid-mac80211-warning-on-bad-ra.patch
+++ b/package/kernel/mac80211/patches/subsys/357-wifi-mac80211_hwsim-avoid-mac80211-warning-on-bad-ra.patch
@@ -1,0 +1,31 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Wed, 5 Oct 2022 15:10:09 +0200
+Subject: [PATCH] wifi: mac80211_hwsim: avoid mac80211 warning on bad
+ rate
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit 1833b6f46d7e2830251a063935ab464256defe22 upstream.
+
+If the tool on the other side (e.g. wmediumd) gets confused
+about the rate, we hit a warning in mac80211. Silence that
+by effectively duplicating the check here and dropping the
+frame silently (in mac80211 it's dropped with the warning).
+
+Reported-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Tested-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/drivers/net/wireless/mac80211_hwsim.c
++++ b/drivers/net/wireless/mac80211_hwsim.c
+@@ -3757,6 +3757,8 @@ static int hwsim_cloned_frame_received_n
+ 
+ 	rx_status.band = channel->band;
+ 	rx_status.rate_idx = nla_get_u32(info->attrs[HWSIM_ATTR_RX_RATE]);
++	if (rx_status.rate_idx >= data2->hw->wiphy->bands[rx_status.band]->n_bitrates)
++		goto out;
+ 	rx_status.signal = nla_get_u32(info->attrs[HWSIM_ATTR_SIGNAL]);
+ 
+ 	hdr = (void *)skb->data;

--- a/package/kernel/mac80211/patches/subsys/358-wifi-mac80211-fix-crash-in-beacon-protection-for-P2P.patch
+++ b/package/kernel/mac80211/patches/subsys/358-wifi-mac80211-fix-crash-in-beacon-protection-for-P2P.patch
@@ -1,0 +1,52 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Wed, 5 Oct 2022 21:24:10 +0200
+Subject: [PATCH] wifi: mac80211: fix crash in beacon protection for
+ P2P-device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit b2d03cabe2b2e150ff5a381731ea0355459be09f upstream.
+
+If beacon protection is active but the beacon cannot be
+decrypted or is otherwise malformed, we call the cfg80211
+API to report this to userspace, but that uses a netdev
+pointer, which isn't present for P2P-Device. Fix this to
+call it only conditionally to ensure cfg80211 won't crash
+in the case of P2P-Device.
+
+This fixes CVE-2022-42722.
+
+Reported-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Fixes: 9eaf183af741 ("mac80211: Report beacon protection failures to user space")
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/rx.c
++++ b/net/mac80211/rx.c
+@@ -1987,10 +1987,11 @@ ieee80211_rx_h_decrypt(struct ieee80211_
+ 
+ 		if (mmie_keyidx < NUM_DEFAULT_KEYS + NUM_DEFAULT_MGMT_KEYS ||
+ 		    mmie_keyidx >= NUM_DEFAULT_KEYS + NUM_DEFAULT_MGMT_KEYS +
+-		    NUM_DEFAULT_BEACON_KEYS) {
+-			cfg80211_rx_unprot_mlme_mgmt(rx->sdata->dev,
+-						     skb->data,
+-						     skb->len);
++				   NUM_DEFAULT_BEACON_KEYS) {
++			if (rx->sdata->dev)
++				cfg80211_rx_unprot_mlme_mgmt(rx->sdata->dev,
++							     skb->data,
++							     skb->len);
+ 			return RX_DROP_MONITOR; /* unexpected BIP keyidx */
+ 		}
+ 
+@@ -2138,7 +2139,8 @@ ieee80211_rx_h_decrypt(struct ieee80211_
+ 	/* either the frame has been decrypted or will be dropped */
+ 	status->flag |= RX_FLAG_DECRYPTED;
+ 
+-	if (unlikely(ieee80211_is_beacon(fc) && result == RX_DROP_UNUSABLE))
++	if (unlikely(ieee80211_is_beacon(fc) && result == RX_DROP_UNUSABLE &&
++		     rx->sdata->dev))
+ 		cfg80211_rx_unprot_mlme_mgmt(rx->sdata->dev,
+ 					     skb->data, skb->len);
+ 

--- a/package/kernel/mac80211/patches/subsys/359-wifi-cfg80211-update-hidden-BSSes-to-avoid-WARN_ON.patch
+++ b/package/kernel/mac80211/patches/subsys/359-wifi-cfg80211-update-hidden-BSSes-to-avoid-WARN_ON.patch
@@ -1,0 +1,85 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Wed, 5 Oct 2022 23:11:43 +0200
+Subject: [PATCH] wifi: cfg80211: update hidden BSSes to avoid WARN_ON
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit c90b93b5b782891ebfda49d4e5da36632fefd5d1 upstream.
+
+When updating beacon elements in a non-transmitted BSS,
+also update the hidden sub-entries to the same beacon
+elements, so that a future update through other paths
+won't trigger a WARN_ON().
+
+The warning is triggered because the beacon elements in
+the hidden BSSes that are children of the BSS should
+always be the same as in the parent.
+
+Reported-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Tested-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Fixes: 0b8fb8235be8 ("cfg80211: Parsing of Multiple BSSID information in scanning")
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/wireless/scan.c
++++ b/net/wireless/scan.c
+@@ -1602,6 +1602,23 @@ struct cfg80211_non_tx_bss {
+ 	u8 bssid_index;
+ };
+ 
++static void cfg80211_update_hidden_bsses(struct cfg80211_internal_bss *known,
++					 const struct cfg80211_bss_ies *new_ies,
++					 const struct cfg80211_bss_ies *old_ies)
++{
++	struct cfg80211_internal_bss *bss;
++
++	/* Assign beacon IEs to all sub entries */
++	list_for_each_entry(bss, &known->hidden_list, hidden_list) {
++		const struct cfg80211_bss_ies *ies;
++
++		ies = rcu_access_pointer(bss->pub.beacon_ies);
++		WARN_ON(ies != old_ies);
++
++		rcu_assign_pointer(bss->pub.beacon_ies, new_ies);
++	}
++}
++
+ static bool
+ cfg80211_update_known_bss(struct cfg80211_registered_device *rdev,
+ 			  struct cfg80211_internal_bss *known,
+@@ -1625,7 +1642,6 @@ cfg80211_update_known_bss(struct cfg8021
+ 			kfree_rcu((struct cfg80211_bss_ies *)old, rcu_head);
+ 	} else if (rcu_access_pointer(new->pub.beacon_ies)) {
+ 		const struct cfg80211_bss_ies *old;
+-		struct cfg80211_internal_bss *bss;
+ 
+ 		if (known->pub.hidden_beacon_bss &&
+ 		    !list_empty(&known->hidden_list)) {
+@@ -1653,16 +1669,7 @@ cfg80211_update_known_bss(struct cfg8021
+ 		if (old == rcu_access_pointer(known->pub.ies))
+ 			rcu_assign_pointer(known->pub.ies, new->pub.beacon_ies);
+ 
+-		/* Assign beacon IEs to all sub entries */
+-		list_for_each_entry(bss, &known->hidden_list, hidden_list) {
+-			const struct cfg80211_bss_ies *ies;
+-
+-			ies = rcu_access_pointer(bss->pub.beacon_ies);
+-			WARN_ON(ies != old);
+-
+-			rcu_assign_pointer(bss->pub.beacon_ies,
+-					   new->pub.beacon_ies);
+-		}
++		cfg80211_update_hidden_bsses(known, new->pub.beacon_ies, old);
+ 
+ 		if (old)
+ 			kfree_rcu((struct cfg80211_bss_ies *)old, rcu_head);
+@@ -2312,6 +2319,8 @@ cfg80211_update_notlisted_nontrans(struc
+ 	} else {
+ 		old = rcu_access_pointer(nontrans_bss->beacon_ies);
+ 		rcu_assign_pointer(nontrans_bss->beacon_ies, new_ies);
++		cfg80211_update_hidden_bsses(bss_from_pub(nontrans_bss),
++					     new_ies, old);
+ 		rcu_assign_pointer(nontrans_bss->ies, new_ies);
+ 		if (old)
+ 			kfree_rcu((struct cfg80211_bss_ies *)old, rcu_head);

--- a/package/kernel/mac80211/patches/subsys/500-mac80211_configure_antenna_gain.patch
+++ b/package/kernel/mac80211/patches/subsys/500-mac80211_configure_antenna_gain.patch
@@ -87,7 +87,7 @@
  	CFG80211_TESTMODE_DUMP(ieee80211_testmode_dump)
 --- a/net/mac80211/ieee80211_i.h
 +++ b/net/mac80211/ieee80211_i.h
-@@ -1441,6 +1441,7 @@ struct ieee80211_local {
+@@ -1442,6 +1442,7 @@ struct ieee80211_local {
  	int dynamic_ps_forced_timeout;
  
  	int user_power_level; /* in dBm, for all interfaces */

--- a/package/kernel/mac80211/patches/subsys/600-mac80211-allow-vht-on-2g.patch
+++ b/package/kernel/mac80211/patches/subsys/600-mac80211-allow-vht-on-2g.patch
@@ -12,7 +12,7 @@
  		have_80mhz = true;
 --- a/net/mac80211/util.c
 +++ b/net/mac80211/util.c
-@@ -1919,7 +1919,8 @@ static int ieee80211_build_preq_ies_band
+@@ -1925,7 +1925,8 @@ static int ieee80211_build_preq_ies_band
  	/* Check if any channel in this sband supports at least 80 MHz */
  	for (i = 0; i < sband->n_channels; i++) {
  		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
@@ -24,7 +24,7 @@
  		have_80mhz = true;
 --- a/net/mac80211/mlme.c
 +++ b/net/mac80211/mlme.c
-@@ -5090,7 +5090,8 @@ static int ieee80211_prep_channel(struct
+@@ -5116,7 +5116,8 @@ static int ieee80211_prep_channel(struct
  	have_80mhz = false;
  	for (i = 0; i < sband->n_channels; i++) {
  		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |

--- a/package/kernel/mac80211/patches/subsys/800-backport-of_get_mac_address.patch
+++ b/package/kernel/mac80211/patches/subsys/800-backport-of_get_mac_address.patch
@@ -9,4 +9,3 @@
  static inline int backport_of_get_mac_address(struct device_node *np, u8 *mac_out)
  {
  	const void *mac = of_get_mac_address(np);
-

--- a/package/kernel/mac80211/patches/subsys/800-ethtool_ringparam.patch
+++ b/package/kernel/mac80211/patches/subsys/800-ethtool_ringparam.patch
@@ -1,5 +1,3 @@
-diff --git a/net/mac80211/ethtool.c b/net/mac80211/ethtool.c
-index 99a2e30b3833a6..b2253df54413fb 100644
 --- a/net/mac80211/ethtool.c
 +++ b/net/mac80211/ethtool.c
 @@ -14,7 +14,13 @@
@@ -16,7 +14,7 @@ index 99a2e30b3833a6..b2253df54413fb 100644
  {
  	struct ieee80211_local *local = wiphy_priv(dev->ieee80211_ptr->wiphy);
  
-@@ -25,7 +31,13 @@
+@@ -25,7 +31,13 @@ static int ieee80211_set_ringparam(struc
  }
  
  static void ieee80211_get_ringparam(struct net_device *dev,
@@ -29,3 +27,4 @@ index 99a2e30b3833a6..b2253df54413fb 100644
 +#endif
  {
  	struct ieee80211_local *local = wiphy_priv(dev->ieee80211_ptr->wiphy);
+ 


### PR DESCRIPTION
* mac80211: backport security fixes

This mainly affects scanning and beacon parsing, especially with MBSSID enabled

Fixes: CVE-2022-41674
Fixes: CVE-2022-42719
Fixes: CVE-2022-42720
Fixes: CVE-2022-42721
Fixes: CVE-2022-42722
Signed-off-by: Felix Fietkau <nbd@nbd.name>
(cherry-picked from commit 26f400210d6b3780fcc0deb89b9741837df9c8b8)

* mac80211: refresh patches

355-wifi-cfg80211-fix-BSS-refcounting-bugs.patch - https://github.com/gregkh/linux/commit/5a52384a513462a16335a26b9082b8a0edb24cda

Co-authored-by: Felix Fietkau <nbd@nbd.name>
Co-authored-by: 1054009064 <1054009064@users.noreply.github.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
